### PR TITLE
Disable packing for packages that are only used internally.

### DIFF
--- a/src/Dfe.SignIn.Core.InternalModels/Dfe.SignIn.Core.InternalModels.csproj
+++ b/src/Dfe.SignIn.Core.InternalModels/Dfe.SignIn.Core.InternalModels.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Dfe.SignIn.Core.UseCases/Dfe.SignIn.Core.UseCases.csproj
+++ b/src/Dfe.SignIn.Core.UseCases/Dfe.SignIn.Core.UseCases.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Dfe.SignIn.Gateways.SelectOrganisation.DistributedCache/Dfe.SignIn.Gateways.SelectOrganisation.DistributedCache.csproj
+++ b/src/Dfe.SignIn.Gateways.SelectOrganisation.DistributedCache/Dfe.SignIn.Gateways.SelectOrganisation.DistributedCache.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dfe.SignIn.NodeApiClient/Dfe.SignIn.NodeApiClient.csproj
+++ b/src/Dfe.SignIn.NodeApiClient/Dfe.SignIn.NodeApiClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
This change can be reverted in the future if this doesn't work as expected; however, these specific packages likely to do not need to be published to the NuGet store.