### PR TITLE
Make `SelectOrganisationCallbackBasic.LegalName` optional

### DIFF
--- a/src/Dfe.SignIn.Core.ExternalModels/SelectOrganisation/SelectOrganisationCallbackData.cs
+++ b/src/Dfe.SignIn.Core.ExternalModels/SelectOrganisation/SelectOrganisationCallbackData.cs
@@ -145,7 +145,7 @@ public record SelectOrganisationCallbackBasic()
     /// <summary>
     /// Gets the legal name of the organisation.
     /// </summary>
-    public required string LegalName { get; init; }
+    public string? LegalName { get; init; }
 
     // TODO: Add missing properties...
     //   category - Category of the organisation.


### PR DESCRIPTION
This is because the mid-tier API doesn't always provide this value.