### PR TITLE
[DSI-7699] Resolve app insights healthcheck

### DIFF
--- a/src/Dfe.SignIn.PublicApi/Configuration/HealthCheckExtensions.cs
+++ b/src/Dfe.SignIn.PublicApi/Configuration/HealthCheckExtensions.cs
@@ -24,9 +24,12 @@ public static class HealthCheckExtensions
         ArgumentNullException.ThrowIfNull(services, nameof(services));
         ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
 
+        string connectionString = configuration.GetValue<string>("ConnectionString")
+            ?? throw new InvalidOperationException("Missing connection string for Redis.");
+
         services.AddHealthChecks()
             .AddRedis(
-                redisConnectionString: configuration?.GetConnectionString("SelectSessionRedis") ?? string.Empty,
+                redisConnectionString: connectionString,
                 name: "redis",
                 failureStatus: HealthStatus.Unhealthy,
                 timeout: TimeSpan.FromSeconds(5)

--- a/src/Dfe.SignIn.PublicApi/Configuration/HealthCheckExtensions.cs
+++ b/src/Dfe.SignIn.PublicApi/Configuration/HealthCheckExtensions.cs
@@ -40,11 +40,11 @@ public static class HealthCheckExtensions
     /// Expose the heathcheck via an endpoint.
     /// </summary>
     /// <param name="builder">The builder to register the healthchecks on.</param>
-    /// <param name="endpoint">The endpoint which healthchecks will be made available, defaulting to '/healthcheck'.</param>
+    /// <param name="endpoint">The endpoint which healthchecks will be made available, defaulting to '/v2/healthcheck'.</param>
     /// <exception cref="ArgumentNullException">
     ///   <para>If <paramref name="builder"/> is null.</para>
     /// </exception>
-    public static void UseHealthChecks(this IApplicationBuilder builder, string endpoint = "/healthcheck")
+    public static void UseHealthChecks(this IApplicationBuilder builder, string endpoint = "/v2/healthcheck")
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
 

--- a/src/Dfe.SignIn.SelectOrganisation.Web/Configuration/HealthCheckExtensions.cs
+++ b/src/Dfe.SignIn.SelectOrganisation.Web/Configuration/HealthCheckExtensions.cs
@@ -24,9 +24,12 @@ public static class HealthCheckExtensions
         ArgumentNullException.ThrowIfNull(services, nameof(services));
         ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
 
+        string connectionString = configuration.GetValue<string>("ConnectionString")
+            ?? throw new InvalidOperationException("Missing connection string for Redis.");
+
         services.AddHealthChecks()
             .AddRedis(
-                redisConnectionString: configuration?.GetConnectionString("SelectSessionRedis") ?? string.Empty,
+                redisConnectionString: connectionString,
                 name: "redis",
                 failureStatus: HealthStatus.Unhealthy,
                 timeout: TimeSpan.FromSeconds(5)

--- a/src/Dfe.SignIn.SelectOrganisation.Web/Configuration/HealthCheckExtensions.cs
+++ b/src/Dfe.SignIn.SelectOrganisation.Web/Configuration/HealthCheckExtensions.cs
@@ -40,11 +40,11 @@ public static class HealthCheckExtensions
     /// Expose the heathcheck via an endpoint.
     /// </summary>
     /// <param name="builder">The builder to register the healthchecks on.</param>
-    /// <param name="endpoint">The endpoint which healthchecks will be made available, defaulting to '/healthcheck'.</param>
+    /// <param name="endpoint">The endpoint which healthchecks will be made available, defaulting to '/v2/healthcheck'.</param>
     /// <exception cref="ArgumentNullException">
     ///   <para>If <paramref name="builder"/> is null.</para>
     /// </exception>
-    public static void UseHealthChecks(this IApplicationBuilder builder, string endpoint = "/healthcheck")
+    public static void UseHealthChecks(this IApplicationBuilder builder, string endpoint = "/v2/healthcheck")
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
 

--- a/tests/Dfe.SignIn.PublicApi.UnitTests/Configuration/HealthCheckExtensionsTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.UnitTests/Configuration/HealthCheckExtensionsTests.cs
@@ -39,7 +39,7 @@ public sealed class HealthCheckExtensionsTests
     public void SetupHealthChecks_AddsHealthChecksService()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationRoot([]);
+        var configuration = GetFakeConfiguration();
 
         services.SetupHealthChecks(configuration);
 
@@ -55,7 +55,7 @@ public sealed class HealthCheckExtensionsTests
     public void SetupHealthChecks_AddsRedisHealthCheckService()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationRoot([]);
+        var configuration = GetFakeConfiguration();
 
         services.SetupHealthChecks(configuration);
 
@@ -65,6 +65,30 @@ public sealed class HealthCheckExtensionsTests
 
         var redisCheck = registrations.FirstOrDefault(r => r.Name == "redis");
         Assert.IsNotNull(redisCheck);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(InvalidOperationException))]
+    public void SetupHealthChecks_Throws_WhenRedisConnectionStringIsMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationRoot([]);
+
+        services.SetupHealthChecks(configuration);
+    }
+
+    private static IConfiguration GetFakeConfiguration()
+    {
+        var configurationData = new Dictionary<string, string>
+        {
+            {"ConnectionString", "fakeRedisConnectionString"}
+        };
+
+        var services = new ServiceCollection();
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationData!)
+            .Build();
     }
     #endregion
 }

--- a/tests/Dfe.SignIn.SelectOrganisation.Web.UnitTests/Configuration/HealthCheckExtensionsTests.cs
+++ b/tests/Dfe.SignIn.SelectOrganisation.Web.UnitTests/Configuration/HealthCheckExtensionsTests.cs
@@ -39,7 +39,7 @@ public sealed class HealthCheckExtensionsTests
     public void SetupHealthChecks_AddsHealthChecksService()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationRoot([]);
+        var configuration = GetFakeConfiguration();
 
         services.SetupHealthChecks(configuration);
 
@@ -55,7 +55,7 @@ public sealed class HealthCheckExtensionsTests
     public void SetupHealthChecks_AddsRedisHealthCheckService()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationRoot([]);
+        var configuration = GetFakeConfiguration();
 
         services.SetupHealthChecks(configuration);
 
@@ -65,6 +65,30 @@ public sealed class HealthCheckExtensionsTests
 
         var redisCheck = registrations.FirstOrDefault(r => r.Name == "redis");
         Assert.IsNotNull(redisCheck);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(InvalidOperationException))]
+    public void SetupHealthChecks_Throws_WhenRedisConnectionStringIsMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationRoot([]);
+
+        services.SetupHealthChecks(configuration);
+    }
+
+    private static IConfiguration GetFakeConfiguration()
+    {
+        var configurationData = new Dictionary<string, string>
+        {
+            {"ConnectionString", "fakeRedisConnectionString"}
+        };
+
+        var services = new ServiceCollection();
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationData!)
+            .Build();
     }
     #endregion
 }


### PR DESCRIPTION
### Summary
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-7699

### Changes
- Use `ConnectionString` rather than  `SelectSessionRedis` from the configuration provider for the `redisConnectionString` property
- Register the `healthcheck` endpoint as `/v2/healthcheck` rather than `/healthcheck`, to distinguish between Node and .NET
- Add additional unit tests for increased coverage
