### PR TITLE
Add TimeProvider to PublicKeyCache

### DIFF
--- a/src/Dfe.SignIn.PublicApi.Client/PublicApiExtensions.cs
+++ b/src/Dfe.SignIn.PublicApi.Client/PublicApiExtensions.cs
@@ -33,6 +33,7 @@ public static class PublicApiExtensions
 
         SetupHttpClient(services);
 
+        services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IPublicKeyCache, PublicKeyCache>();
         services.AddSingleton<IPayloadVerifier, DefaultPayloadVerifier>();
 

--- a/src/Dfe.SignIn.PublicApi.Client/PublicApiExtensions.cs
+++ b/src/Dfe.SignIn.PublicApi.Client/PublicApiExtensions.cs
@@ -33,7 +33,12 @@ public static class PublicApiExtensions
 
         SetupHttpClient(services);
 
-        services.AddSingleton(TimeProvider.System);
+        if (!services.Any(serviceDescriptor =>
+            serviceDescriptor.ServiceType == typeof(TimeProvider) ||
+            typeof(TimeProvider).IsAssignableFrom(serviceDescriptor.ServiceType))) {
+            services.AddSingleton(TimeProvider.System);
+        }
+
         services.AddSingleton<IPublicKeyCache, PublicKeyCache>();
         services.AddSingleton<IPayloadVerifier, DefaultPayloadVerifier>();
 

--- a/tests/Dfe.SignIn.PublicApi.Client.UnitTests/PublicApiExtensionsTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.Client.UnitTests/PublicApiExtensionsTests.cs
@@ -133,6 +133,24 @@ public sealed class PublicApiExtensionsTests
     }
 
     [TestMethod]
+    public void SetupDfePublicApiClient_RegistersSupportingInternalServicesConditionallyAddsTimeProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new MockTimeProvider(DateTime.UtcNow));
+
+        services.SetupDfePublicApiClient();
+
+        var timeProviderDescriptors = services.Where(descriptor =>
+            descriptor.Lifetime == ServiceLifetime.Singleton &&
+            (descriptor.ServiceType == typeof(TimeProvider) ||
+            descriptor.ServiceType.IsAssignableTo(typeof(TimeProvider)))
+        ).ToArray();
+
+        Assert.AreEqual(1, timeProviderDescriptors.Length);
+        Assert.AreEqual(typeof(MockTimeProvider), timeProviderDescriptors[0].ServiceType);
+    }
+
+    [TestMethod]
     public void SetupDfePublicApiClient_RegistersSelectOrganisationApiRequesters()
     {
         var services = new ServiceCollection();

--- a/tests/Dfe.SignIn.PublicApi.Client.UnitTests/PublicApiExtensionsTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.Client.UnitTests/PublicApiExtensionsTests.cs
@@ -120,6 +120,13 @@ public sealed class PublicApiExtensionsTests
         Assert.IsTrue(
             services.Any(descriptor =>
                 descriptor.Lifetime == ServiceLifetime.Singleton &&
+                descriptor.ServiceType == typeof(TimeProvider)
+            )
+        );
+
+        Assert.IsTrue(
+            services.Any(descriptor =>
+                descriptor.Lifetime == ServiceLifetime.Singleton &&
                 descriptor.ServiceType == typeof(IPublicKeyCache)
             )
         );

--- a/tests/Dfe.SignIn.PublicApi.Client.UnitTests/PublicKeyCacheTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.Client.UnitTests/PublicKeyCacheTests.cs
@@ -78,7 +78,8 @@ public sealed class PublicKeyCacheTests
     private static void UseMockedOptions(
         AutoMocker autoMocker,
         int ttlMilliseconds = 500,
-        int maximumRefreshIntervalMilliseconds = 250)
+        int maximumRefreshIntervalMilliseconds = 250,
+        TimeProvider? timeProvider = null)
     {
         autoMocker.GetMock<IOptions<PublicApiOptions>>()
             .Setup(x => x.Value)
@@ -94,6 +95,8 @@ public sealed class PublicKeyCacheTests
                 TTL = new TimeSpan(days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: ttlMilliseconds),
                 MaximumRefreshInterval = new TimeSpan(days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: maximumRefreshIntervalMilliseconds),
             });
+
+        autoMocker.Use(timeProvider ?? TimeProvider.System);
     }
 
     private static void UseHttpClient(AutoMocker autoMocker, HttpClient httpClient)
@@ -156,6 +159,23 @@ public sealed class PublicKeyCacheTests
             .Throws<HttpRequestException>();
 
         UseHttpClient(autoMocker, new HttpClient(mockHttp.Object));
+    }
+
+    private class MockTimeProvider : TimeProvider
+    {
+        private DateTimeOffset utcNow;
+
+        public MockTimeProvider(DateTimeOffset startTime)
+        {
+            this.utcNow = startTime;
+        }
+
+        public override DateTimeOffset GetUtcNow() => this.utcNow;
+
+        public void Advance(TimeSpan timeSpan)
+        {
+            this.utcNow = this.utcNow.Add(timeSpan);
+        }
     }
 
     #region GetPublicKeyAsync(string)
@@ -240,13 +260,14 @@ public sealed class PublicKeyCacheTests
     public async Task GetPublicKeyAsync_FetchesFreshPublicKeys_WhenTtlHasElapsed()
     {
         var autoMocker = new AutoMocker();
-        UseMockedOptions(autoMocker, ttlMilliseconds: 10, maximumRefreshIntervalMilliseconds: 0);
+        var timeProvider = new MockTimeProvider(DateTime.UtcNow);
+        UseMockedOptions(autoMocker, ttlMilliseconds: 10, maximumRefreshIntervalMilliseconds: 0, timeProvider: timeProvider);
         UseHttpClientWithFakeResponse(autoMocker, FakeKeyHttpResponse);
 
         var publicKeyCache = autoMocker.CreateInstance<PublicKeyCache>();
 
         await publicKeyCache.GetPublicKeyAsync("FakePublicKey1");
-        await Task.Delay(millisecondsDelay: 15);
+        timeProvider.Advance(TimeSpan.FromMinutes(120));
         await publicKeyCache.GetPublicKeyAsync("FakePublicKey1");
 
         autoMocker.GetMock<HttpMessageHandler>().Protected()

--- a/tests/Dfe.SignIn.PublicApi.Client.UnitTests/PublicKeyCacheTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.Client.UnitTests/PublicKeyCacheTests.cs
@@ -161,23 +161,6 @@ public sealed class PublicKeyCacheTests
         UseHttpClient(autoMocker, new HttpClient(mockHttp.Object));
     }
 
-    private class MockTimeProvider : TimeProvider
-    {
-        private DateTimeOffset utcNow;
-
-        public MockTimeProvider(DateTimeOffset startTime)
-        {
-            this.utcNow = startTime;
-        }
-
-        public override DateTimeOffset GetUtcNow() => this.utcNow;
-
-        public void Advance(TimeSpan timeSpan)
-        {
-            this.utcNow = this.utcNow.Add(timeSpan);
-        }
-    }
-
     #region GetPublicKeyAsync(string)
 
     [TestMethod]

--- a/tests/Dfe.SignIn.TestHelpers/MockTimeProvider.cs
+++ b/tests/Dfe.SignIn.TestHelpers/MockTimeProvider.cs
@@ -1,0 +1,33 @@
+namespace Dfe.SignIn.TestHelpers;
+
+/// <summary>
+/// An implementation of TimeProvider for mocking purposes.
+/// </summary>
+public sealed class MockTimeProvider : TimeProvider
+{
+    private DateTimeOffset utcNow;
+
+    /// <summary>
+    /// Construct an instance of MockTimeProvider.
+    /// </summary>
+    /// <param name="startTime">The moment in time which to start from.</param>
+    public MockTimeProvider(DateTimeOffset startTime)
+    {
+        this.utcNow = startTime;
+    }
+
+    /// <summary>
+    /// Gets the current DateTimeOffset associated with the instance.
+    /// </summary>
+    /// <returns></returns>
+    public override DateTimeOffset GetUtcNow() => this.utcNow;
+
+    /// <summary>
+    /// Advance the DateTimeOffset.
+    /// </summary>
+    /// <param name="timeSpan">Adjust the DateTimeOffset by the provided TimeSpan.</param>
+    public void Advance(TimeSpan timeSpan)
+    {
+        this.utcNow = this.utcNow.Add(timeSpan);
+    }
+}


### PR DESCRIPTION
### Summary

Provide a TimeProvider into the constructor of PublicKeyCache, such that "time" can be mocked.

### Changes
- Add TimeProvider as a constructor parameter to PublicKeyCache 
- Update PublicKeyCache to utilise TimeProviders UtcDateTime
- Update PublicApiExtensions to register a singleton instance of TimeProvider, for DI into PublicKeyCache
- Add a Mocked TimeProvider for testing
- Update tests to register/use MockTimeProvider and eliminate Task.Delay



