### PR TITLE
Resolve issue on Windows where `npm --prefix` does not work as expected.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,15 +33,15 @@ A custom "dsi" template has been created to give the DfE Sign-in Developer Refer
 Node tooling is required to bundle and minify the scripts and styles.
 
 ```pwsh
-# run from root of repository /
-npm --prefix docs/templates i
+# run from root of repository /docs/templates/
+npm i
 ```
 
 With the developer tooling installed:
 
 ```pwsh
-# run from root of repository /
-npm --prefix docs/templates run build
+# run from root of repository /docs/templates/
+npm run build
 ```
 
 > **Note:** Scripts and styles can also be built by running `./scripts/docs/Build-CustomTemplate.ps1`.
@@ -51,8 +51,8 @@ npm --prefix docs/templates run build
 The following command can be executed from the "docs" directory:
 
 ```pwsh
-# run from root of repository /
-dotnet build docs/templates
+# run from root of repository /docs/templates/
+dotnet build .
 ```
 
 Upon running this command the plugin DLL files are copied into the "dsi/plugins" directory.

--- a/scripts/docs/Build-CustomTemplate.ps1
+++ b/scripts/docs/Build-CustomTemplate.ps1
@@ -1,5 +1,8 @@
 $docsPath = Resolve-Path "${PSScriptRoot}/../../docs"
 
-npm --prefix "$docsPath/templates" install
-npm --prefix "$docsPath/templates" run build
+pwsh -WorkingDirectory "$docsPath/templates" -Command {
+    npm install
+    npm run build
+}
+
 dotnet build "$docsPath/templates"


### PR DESCRIPTION
The `npm --prefix` switch is being ignored when developers run the command on Windows. This seems to be a known issue: https://github.com/npm/cli/issues/4511

The workaround is to create a nested shell with the correct working directory which should work well for developers on Mac and Windows.