### PR TITLE
Fix issue where casing of 'code' in callback was incorrect

### DIFF
--- a/src/Dfe.SignIn.Core.ExternalModels/SelectOrganisation/CallbackParamNames.cs
+++ b/src/Dfe.SignIn.Core.ExternalModels/SelectOrganisation/CallbackParamNames.cs
@@ -25,7 +25,7 @@ public static class CallbackParamNames
     /// Name of the parameter that specifies the error code.
     /// </summary>
     /// <remarks>
-    ///   <para>Parameter value type: <see cref="SelectOrganisationErrorCode"/>.</para>
+    ///   <para>Parameter value type: <see cref="string"/> (see <see cref="SelectOrganisationErrorCode"/>).</para>
     /// </remarks>
     public const string ErrorCode = "code";
 

--- a/src/Dfe.SignIn.Core.ExternalModels/SelectOrganisation/SelectOrganisationErrorCode.cs
+++ b/src/Dfe.SignIn.Core.ExternalModels/SelectOrganisation/SelectOrganisationErrorCode.cs
@@ -1,22 +1,23 @@
 namespace Dfe.SignIn.Core.ExternalModels.SelectOrganisation;
 
 /// <summary>
-/// Indicates the type of error that has occurred.
+/// Constant values representing the different error codes resulting for a failed
+/// "select organisation" callback.
 /// </summary>
-public enum SelectOrganisationErrorCode
+public static class SelectOrganisationErrorCode
 {
     /// <summary>
     /// Indicates that an internal error has occurred.
     /// </summary>
-    InternalError = 0,
+    public const string InternalError = "internalError";
 
     /// <summary>
     /// Indicates that an invalid selection was made.
     /// </summary>
-    InvalidSelection = 1,
+    public const string InvalidSelection = "invalidSelection";
 
     /// <summary>
     /// Indicates that there were no options for the user to choose from.
     /// </summary>
-    NoOptions = 2,
+    public const string NoOptions = "noOptions";
 }

--- a/src/Dfe.SignIn.PublicApi.Client/SelectOrganisation/SelectOrganisationCallbackErrorException.cs
+++ b/src/Dfe.SignIn.PublicApi.Client/SelectOrganisation/SelectOrganisationCallbackErrorException.cs
@@ -37,8 +37,10 @@ public sealed class SelectOrganisationCallbackErrorException : Exception
     /// <summary>
     /// Initializes a new instance of the <see cref="SelectOrganisationCallbackErrorException"/> class.
     /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
     /// <param name="errorCode">A value indicating the kind of error that has occurred.</param>
-    public SelectOrganisationCallbackErrorException(SelectOrganisationErrorCode errorCode)
+    public SelectOrganisationCallbackErrorException(string? message, string errorCode)
+        : base(message)
     {
         this.ErrorCode = errorCode;
     }
@@ -46,6 +48,7 @@ public sealed class SelectOrganisationCallbackErrorException : Exception
     /// <summary>
     /// Gets a value indicating the kind of error that has occurred.
     /// </summary>
+    /// <seealso cref="SelectOrganisationErrorCode"/>
     [Persist]
-    public SelectOrganisationErrorCode ErrorCode { get; }
+    public string ErrorCode { get; } = SelectOrganisationErrorCode.InternalError;
 }

--- a/src/Dfe.SignIn.PublicApi.Client/SelectOrganisation/SelectOrganisationUserFlow.cs
+++ b/src/Dfe.SignIn.PublicApi.Client/SelectOrganisation/SelectOrganisationUserFlow.cs
@@ -86,7 +86,8 @@ public interface ISelectOrganisationEvents
     /// <exception cref="SelectOrganisationCallbackErrorException">
     ///   <para>If the handler implementation chooses to throw as exception.</para>
     /// </exception>
-    Task OnError(IHttpContext context, SelectOrganisationErrorCode code);
+    /// <seealso cref="SelectOrganisationErrorCode"/>
+    Task OnError(IHttpContext context, string code);
 
     /// <summary>
     /// The event occurs when the user has selected an organisation and the selection

--- a/src/Dfe.SignIn.PublicApi.Client/SelectOrganisation/StandardSelectOrganisationEvents.cs
+++ b/src/Dfe.SignIn.PublicApi.Client/SelectOrganisation/StandardSelectOrganisationEvents.cs
@@ -50,9 +50,9 @@ public class StandardSelectOrganisationEvents(
     }
 
     /// <inheritdoc/>
-    public virtual Task OnError(IHttpContext context, SelectOrganisationErrorCode code)
+    public virtual Task OnError(IHttpContext context, string code)
     {
-        throw new SelectOrganisationCallbackErrorException(code);
+        throw new SelectOrganisationCallbackErrorException(null, code);
     }
 
     /// <inheritdoc/>

--- a/src/Dfe.SignIn.PublicApi.Client/SelectOrganisation/StandardSelectOrganisationUserFlow.cs
+++ b/src/Dfe.SignIn.PublicApi.Client/SelectOrganisation/StandardSelectOrganisationUserFlow.cs
@@ -108,13 +108,10 @@ public sealed class StandardSelectOrganisationUserFlow(
         }
     }
 
-    private static SelectOrganisationErrorCode ParseErrorCode(IHttpContext context)
+    private static string ParseErrorCode(IHttpContext context)
     {
-        string errorCodeRaw = context.Request.GetRequiredQuery(CallbackParamNames.ErrorCode)!;
-        if (!Enum.TryParse<SelectOrganisationErrorCode>(errorCodeRaw, out var errorCode)) {
-            errorCode = SelectOrganisationErrorCode.InternalError;
-        }
-        return errorCode;
+        return context.Request.GetRequiredQuery(CallbackParamNames.ErrorCode)
+            ?? SelectOrganisationErrorCode.InternalError;
     }
 
     private static Guid ParseSelectedOrganisationId(IHttpContext context)

--- a/src/Dfe.SignIn.Web.SelectOrganisation/Controllers/SelectOrganisationController.cs
+++ b/src/Dfe.SignIn.Web.SelectOrganisation/Controllers/SelectOrganisationController.cs
@@ -150,8 +150,7 @@ public sealed class SelectOrganisationController(
         return this.Redirect($"{session.CallbackUrl}&{CallbackParamNames.Type}={CallbackTypes.Selection}&{CallbackParamNames.Selection}={selection}");
     }
 
-    private IActionResult RedirectToErrorCallback(
-        SelectOrganisationSessionData session, SelectOrganisationErrorCode errorCode)
+    private IActionResult RedirectToErrorCallback(SelectOrganisationSessionData session, string errorCode)
     {
         return this.Redirect($"{session.CallbackUrl}&{CallbackParamNames.Type}={CallbackTypes.Error}&{CallbackParamNames.ErrorCode}={errorCode}");
     }

--- a/tests/Dfe.SignIn.PublicApi.Client.UnitTests/SelectOrganisation/SelectOrganisationCallbackErrorExceptionTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.Client.UnitTests/SelectOrganisation/SelectOrganisationCallbackErrorExceptionTests.cs
@@ -11,7 +11,7 @@ public sealed class SelectOrganisationCallbackErrorExceptionTests
     [TestMethod]
     public void ErrorCode_HasInitializedValue()
     {
-        var exception = new SelectOrganisationCallbackErrorException(SelectOrganisationErrorCode.InvalidSelection);
+        var exception = new SelectOrganisationCallbackErrorException(null, SelectOrganisationErrorCode.InvalidSelection);
 
         Assert.AreEqual(SelectOrganisationErrorCode.InvalidSelection, exception.ErrorCode);
     }

--- a/tests/Dfe.SignIn.PublicApi.Client.UnitTests/SelectOrganisation/StandardSelectOrganisationEventsTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.Client.UnitTests/SelectOrganisation/StandardSelectOrganisationEventsTests.cs
@@ -159,13 +159,13 @@ public sealed class StandardSelectOrganisationEventsTests
 
     #endregion
 
-    #region OnError(IHttpContext, SelectOrganisationErrorCode)
+    #region OnError(IHttpContext, string)
 
     [TestMethod]
     public async Task OnError_Throws()
     {
         var autoMocker = new AutoMocker();
-        var options = SetupMockOptions(autoMocker);
+        SetupMockOptions(autoMocker);
         var mockContext = SetupMockHttpContext(autoMocker);
         var events = autoMocker.CreateInstance<StandardSelectOrganisationEvents>();
 

--- a/tests/Dfe.SignIn.PublicApi.Client.UnitTests/SelectOrganisation/StandardSelectOrganisationUserFlowTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.Client.UnitTests/SelectOrganisation/StandardSelectOrganisationUserFlowTests.cs
@@ -445,7 +445,7 @@ public sealed class StandardSelectOrganisationUserFlowTests
         autoMocker.Verify<ISelectOrganisationEvents>(mock =>
             mock.OnError(
                 It.Is<IHttpContext>(context => context == fakeContext.Object),
-                It.Is<SelectOrganisationErrorCode>(errorCode => errorCode == SelectOrganisationErrorCode.InvalidSelection)
+                It.Is<string>(errorCode => errorCode == SelectOrganisationErrorCode.InvalidSelection)
             ),
             Times.Once
         );
@@ -524,7 +524,7 @@ public sealed class StandardSelectOrganisationUserFlowTests
         autoMocker.Verify<ISelectOrganisationEvents>(mock =>
             mock.OnError(
                 It.Is<IHttpContext>(context => context == fakeContext.Object),
-                It.Is<SelectOrganisationErrorCode>(errorCode => errorCode == SelectOrganisationErrorCode.InvalidSelection)
+                It.Is<string>(errorCode => errorCode == SelectOrganisationErrorCode.InvalidSelection)
             ),
             Times.Once
         );
@@ -562,7 +562,7 @@ public sealed class StandardSelectOrganisationUserFlowTests
         autoMocker.Verify<ISelectOrganisationEvents>(mock =>
             mock.OnError(
                 It.Is<IHttpContext>(context => context == fakeContext.Object),
-                It.Is<SelectOrganisationErrorCode>(errorCode => errorCode == SelectOrganisationErrorCode.InvalidSelection)
+                It.Is<string>(errorCode => errorCode == SelectOrganisationErrorCode.InvalidSelection)
             ),
             Times.Once
         );


### PR DESCRIPTION
Character casing of error code in callbacks was PascalCase rather than camelCase.

## Expected output:
```
https://example.localhost/callback?rid=...&type=error&code=noOptions
```

## Actual output:
```
https://example.localhost/callback?rid=...&type=error&code=NoOptions
```

## Resolution
Use string constants instead to ensure consistency.