### PR TITLE
[DSI-7818] Fix issue where docker manifest type was incompatible with app services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,8 @@ jobs:
     uses: ./.github/workflows/dotnet-packages.yml
     needs: prepare
     if: "${{ needs.prepare.outputs.publish_dotnet_packages == 'true' }}"
+    permissions:
+      id-token: write # Needed by 'azure/login'
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -195,7 +197,6 @@ jobs:
     if: "${{ needs.prepare.outputs.check_docs_templates == 'true' }}"
     permissions:
       checks: write # Needed by 'dorny/test-reporter'.
-      id-token: write # Needed by 'azure/login'
 
   docs-build:
     name: Build external documentation

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -73,7 +73,8 @@ jobs:
           context: .
           file: ./docker/docs/Dockerfile
           platforms: linux/amd64
-          outputs: type=docker
+          outputs: type=image,push=true
+          provenance: false
           load: true
           build-args: |
             PROJECT_NAME=${{ inputs.project_name }}

--- a/.github/workflows/dotnet-build-image.yml
+++ b/.github/workflows/dotnet-build-image.yml
@@ -70,7 +70,8 @@ jobs:
           context: .
           file: ./docker/dotnet/Dockerfile
           platforms: linux/amd64
-          outputs: type=docker
+          outputs: type=image,push=true
+          provenance: false
           load: true
           build-args: |
             PROJECT_NAME=${{ inputs.project_name }}


### PR DESCRIPTION
An error is being reported when using buildx since it defaults to the `application/vnd.oci.image.index.v1+json` format.

This PR indicates that the v2 format should be used instead.

This PR also moves a permission declaration to the correct job which was causing an issue when publishing NuGet packages (regression from #46).