### PR TITLE
[DSI-7818] Use separate step for 'Build project'

### DIFF
--- a/.github/workflows/dotnet-checks.yml
+++ b/.github/workflows/dotnet-checks.yml
@@ -66,10 +66,15 @@ jobs:
             /d:sonar.token="$env:SONAR_TOKEN" `
             /s:${{ github.workspace }}/SonarQube.Analysis.xml
 
+      - name: Build project
+        run: |
+          dotnet build ./build.sln `
+            --framework net8.0
+
       - name: Run unit tests
         run: |
           dotnet test ./build.sln `
-            --framework net8.0 `
+            --no-build `
             --collect "XPlat Code Coverage" `
             --logger "trx;LogFileName=TestResults.trx"
 


### PR DESCRIPTION
Having a separate step for 'Build project' ensures an earlier failure when a test project cannot build.

This avoids confusing output where unit test projects (the ones that built successfully) appear to pass in the test summary despite one or more test projects failing to build. Whilst the workflow still failed; it wasn't as clear.