### PR TITLE
[DSI-7818] Build packages to "packages" directory for improved performance

### DIFF
--- a/.github/workflows/dotnet-packages.yml
+++ b/.github/workflows/dotnet-packages.yml
@@ -58,7 +58,7 @@ jobs:
             --password "$env:AZURE_DEVOPS_TOKEN" `
             --store-password-in-clear-text
 
-          Get-ChildItem -Path ./src -Recurse -Filter *.nupkg | ForEach-Object {
+          Get-ChildItem -Path ./packages -Filter *.nupkg | ForEach-Object {
             dotnet nuget push $_.FullName `
               --source AzureArtifacts `
               --api-key null `

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
     {
       "label": "dfe: update local feed",
       "type": "shell",
-      "command": "dotnet build -p:IsPipeline=true && dotnet nuget push \"**/*.nupkg\" --source LocalStore",
+      "command": "dotnet build -p:IsPipeline=true && dotnet nuget push \"packages/*.nupkg\" --source LocalStore",
       "problemMatcher": []
     }
   ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,9 @@
 <Project>
    <PropertyGroup>
+      <PackageOutputPath>$(MSBuildThisFileDirectory)packages</PackageOutputPath>
+   </PropertyGroup>
+
+   <PropertyGroup>
       <!-- Warnings are also suppressed in SonarQube UI. -->
       <NoWarn>S2094;S3267;S1066;S2376;S6819;CA1861</NoWarn>
    </PropertyGroup>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -2,7 +2,7 @@
 
   <Target Name="CleanupPreviousNupkgFiles" BeforeTargets="Build" Condition="$(BuildPackages) == 'true'">
     <ItemGroup>
-      <NupkgFiles Include="**/bin/$(Configuration)/*.nupkg" />
+      <NupkgFiles Include="packages/*.nupkg" />
     </ItemGroup>
     <Delete Files="@(NupkgFiles)" />
   </Target>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use the following command to build and push NuGet packages to a local feed:
 
 ```pwsh
 dotnet build /p:BuildPackages=true
-dotnet nuget push "**/*.nupkg" --source LocalStore
+dotnet nuget push "packages/*.nupkg" --source LocalStore
 ```
 
 Alternatively the following can be ran from the Visual Studio Code command palette:


### PR DESCRIPTION
This change avoids recursively searching for `*.nupkg` files when building and publishing NuGet packages.

This change also makes it easier to access the built packages when working with NuGet packages locally.