### PR TITLE
[DSI-8106] Add launch options in Visual Studio Code for developers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,31 +5,97 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "C#: Application - Help",
-      "type": "dotnet",
+      "name": "Frontend Assets",
+      "presentation": {
+        "group": "_shared",
+      },
+      "type": "node",
       "request": "launch",
-      "projectPath": "${workspaceFolder}/src/Dfe.SignIn.Web.Help/Dfe.SignIn.Web.Help.csproj"
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "dfe: start frontend assets",
+      "postDebugTask": "dfe: stop frontend assets",
     },
     {
-      "name": "C#: Application - Public API",
+      "name": "App: Help",
+      "presentation": {
+        "group": "apps",
+      },
       "type": "dotnet",
       "request": "launch",
-      "projectPath": "${workspaceFolder}/src/Dfe.SignIn.PublicApi/Dfe.SignIn.PublicApi.csproj"
+      "projectPath": "${workspaceFolder}/src/Dfe.SignIn.Web.Help/Dfe.SignIn.Web.Help.csproj",
     },
     {
-      "name": "C#: Application - Select Organisation",
+      "name": "App: Public API",
+      "presentation": {
+        "group": "apps",
+      },
       "type": "dotnet",
       "request": "launch",
-      "projectPath": "${workspaceFolder}/src/Dfe.SignIn.Web.SelectOrganisation/Dfe.SignIn.Web.SelectOrganisation.csproj"
+      "projectPath": "${workspaceFolder}/src/Dfe.SignIn.PublicApi/Dfe.SignIn.PublicApi.csproj",
+    },
+    {
+      "name": "App: Select Organisation",
+      "presentation": {
+        "group": "apps",
+      },
+      "type": "dotnet",
+      "request": "launch",
+      "projectPath": "${workspaceFolder}/src/Dfe.SignIn.Web.SelectOrganisation/Dfe.SignIn.Web.SelectOrganisation.csproj",
+    },
+    {
+      "name": "Docs: External",
+      "presentation": {
+        "hidden": true
+      },
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "dfe: start external docs",
+      "postDebugTask": "dfe: stop external docs",
+    },
+    {
+      "name": "Docs: Internal",
+      "presentation": {
+        "hidden": true
+      },
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "dfe: start internal docs",
+      "postDebugTask": "dfe: stop internal docs",
     },
   ],
   "compounds": [
     {
-      "name": "C#: Select Organisation",
+      "name": "External Docs",
+      "presentation": {
+        "group": "docs",
+      },
       "configurations": [
-        "C#: Application - Public API",
-        "C#: Application - Select Organisation"
-      ]
+        "Frontend Assets",
+        "Docs: External",
+      ],
     },
-  ]
+    {
+      "name": "Internal Docs",
+      "presentation": {
+        "group": "docs",
+      },
+      "configurations": [
+        "Frontend Assets",
+        "Docs: Internal",
+      ],
+    },
+    {
+      "name": "Multi: Select Organisation",
+      "presentation": {
+        "group": "sets",
+      },
+      "configurations": [
+        "Frontend Assets",
+        "App: Public API",
+        "App: Select Organisation",
+      ],
+    },
+  ],
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,5 +9,47 @@
       "command": "dotnet build -p:IsPipeline=true && dotnet nuget push \"packages/*.nupkg\" --source LocalStore",
       "problemMatcher": []
     },
+    {
+      "label": "dfe: start frontend assets",
+      "type": "shell",
+      "command": "./scripts/frontend/Start-Frontend.ps1",
+      "problemMatcher": []
+    },
+    {
+      "label": "dfe: stop frontend assets",
+      "type": "shell",
+      "command": "./scripts/docker/Stop-Docker.ps1 -Tag frontend",
+      "problemMatcher": []
+    },
+    {
+      "label": "dfe: start external docs",
+      "type": "shell",
+      "command": "./scripts/docs/Start-Site.ps1 -Name external; open http://localhost:8085",
+      "windows": {
+        "command": "./scripts/docs/Start-Site.ps1 -Name external; start http://localhost:8085"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "dfe: stop external docs",
+      "type": "shell",
+      "command": "./scripts/docker/Stop-Docker.ps1 -Tag external-docs",
+      "problemMatcher": []
+    },
+    {
+      "label": "dfe: start internal docs",
+      "type": "shell",
+      "command": "./scripts/docs/Start-Site.ps1 -Name internal; open http://localhost:8086",
+      "windows": {
+        "command": "./scripts/docs/Start-Site.ps1 -Name internal; start http://localhost:8086"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "dfe: stop internal docs",
+      "type": "shell",
+      "command": "./scripts/docker/Stop-Docker.ps1 -Tag internal-docs",
+      "problemMatcher": []
+    },
   ]
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,25 +6,25 @@ A custom "dsi" template has been created to give the DfE Sign-in Developer Refer
 
 - `external/` - Content and configuration for the external facing documentation website:
 
-  * Guidance that is aimed towards relying parties.
+  - Guidance that is aimed towards relying parties.
 
-  * Stripped down version of the DfE Sign-in .NET API reference documentation which is designed to assist relying parties when integrating with DfE Sign-in.
+  - Stripped down version of the DfE Sign-in .NET API reference documentation which is designed to assist relying parties when integrating with DfE Sign-in.
 
 - `internal/` - Content and configuration for the internal facing documentation website:
 
-  * Guidance that is aimed towards internal DfE Sign-in development team.
+  - Guidance that is aimed towards internal DfE Sign-in development team.
 
-  * Complete version of the DfE Sign-in .NET API reference documentation which is designed to assist the internal DfE Sign-in development team.
+  - Complete version of the DfE Sign-in .NET API reference documentation which is designed to assist the internal DfE Sign-in development team.
 
 - `namespaces/` - Provides documentation content for namespaces.
 
-  * Documentation comments cannot be used to document namespaces within the various .NET projects.
+  - Documentation comments cannot be used to document namespaces within the various .NET projects.
 
 - `templates/Dfe.SignIn.DocfxPlugin/` - A plugin for docfx which post processes output files:
 
-  * `DsiHtmlPostProcessor` - Manipulates generated HTML files to tweak formatting, add GOV.UK design system classes, generate navigation elements, etc.
+  - `DsiHtmlPostProcessor` - Manipulates generated HTML files to tweak formatting, add GOV.UK design system classes, generate navigation elements, etc.
 
-  * `DsiSearchIndexPostProcessor` - Generates the "search.json" index file for use with [Lunr.js](https://lunrjs.com/).
+  - `DsiSearchIndexPostProcessor` - Generates the "search.json" index file for use with [Lunr.js](https://lunrjs.com/).
 
 - `templates/dsi/` - The custom docfx template files.
 
@@ -34,7 +34,7 @@ To build and serve the external documentation locally:
 
 ```pwsh
 # run from root of repository /
-./scripts/docs/Preview-Site external
+./scripts/docs/Start-Site external
 ```
 
 > **Note:** By default the documentation can be viewed on `http://localhost:8085`.
@@ -45,7 +45,7 @@ To build and serve the internal documentation locally:
 
 ```pwsh
 # run from root of repository /
-./scripts/docs/Preview-Site internal
+./scripts/docs/Start-Site internal
 ```
 
 > **Note:** By default the documentation can be viewed on `http://localhost:8086`.
@@ -56,7 +56,7 @@ To build and serve the sample documentation that is used in snapshot testing loc
 
 ```pwsh
 # run from root of repository /
-./scripts/docs/Preview-Site test
+./scripts/docs/Start-Site test
 ```
 
 > **Note:** By default the documentation can be viewed on `http://localhost:8087`.
@@ -73,6 +73,7 @@ dotnet test docs/templates
 Snapshot tests will fail when intentional changes are made to how pages are rendered.
 
 Verify each of the mismatching snapshots manually:
+
 1. Verify that the HTML output is as expected.
 2. Verify that the rendered pages look as expected in a web browser.
 

--- a/scripts/docker/Stop-Docker.ps1
+++ b/scripts/docker/Stop-Docker.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+    Stop localhost server that is previewing frontend assets.
+
+.PARAMETER Tag
+    Tag of the docker image that needs to be stopped.
+
+.EXAMPLE
+    ./scripts/Stop-Docker -Tag frontend
+#>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [String]$Tag
+)
+
+$ErrorActionPreference = "Stop"
+
+docker ps --filter "ancestor=$Tag" | ForEach-Object {
+    if (-not $_.StartsWith("CONTAINER")) {
+        $processId = ($_ -split '\s+')[0]
+        docker stop $processId
+    }
+}

--- a/scripts/docs/Start-Site.Tests.ps1
+++ b/scripts/docs/Start-Site.Tests.ps1
@@ -2,7 +2,7 @@ BeforeAll {
     $Cmdlet = $PSCommandPath.Replace('.Tests.ps1', '.ps1')
 }
 
-Describe "Preview-Site" {
+Describe "Start-Site" {
     BeforeAll {
         Mock Resolve-Path {
             return "."

--- a/scripts/docs/Start-Site.ps1
+++ b/scripts/docs/Start-Site.ps1
@@ -25,13 +25,13 @@
     Output from building the external developer reference documentation site.
 
 .EXAMPLE
-    ./scripts/docs/Preview-Site external
+    ./scripts/docs/Start-Site external
 
 .EXAMPLE
-    ./scripts/docs/Preview-Site internal
+    ./scripts/docs/Start-Site internal
 
 .EXAMPLE
-    ./scripts/docs/Preview-Site test
+    ./scripts/docs/Start-Site test
 #>
 [CmdletBinding()]
 param (
@@ -65,7 +65,7 @@ $root = Resolve-Path "$PSScriptRoot/../.."
 docker build $root -f "$root/docker/docs/Dockerfile" -t $($site.tag) `
     --build-arg PROJECT_NAME=$($site.path)
 
-docker run -p "$($site.port):8080" `
+docker run -d -p "$($site.port):8080" `
     -e CDN_BASE_ADDRESS=http://localhost:8081/ `
     -e SURVEY_URL=https://survey.localhost/ `
     -e _ $($site.tag)

--- a/scripts/frontend/Start-Frontend.ps1
+++ b/scripts/frontend/Start-Frontend.ps1
@@ -29,5 +29,5 @@ $root = Resolve-Path "$PSScriptRoot/../.."
 docker build $root -f "$root/docker/frontend/Dockerfile" -t $($site.tag) `
     --build-arg PROJECT_NAME=$($site.path)
 
-docker run -p "$($site.port):8080" `
+docker run -d -p "$($site.port):8080" `
     -e _ $($site.tag)


### PR DESCRIPTION
These launch options make it easier for developers to launch components when working locally:

<img width="171" height="227" alt="image" src="https://github.com/user-attachments/assets/03aa30e4-f653-4bd0-be79-d589b81b318a" />

The compound launch configurations automatically launch the "Frontend Assets" for convenience.