### PR TITLE
Fix issue where .dockerignore paths were not working as expected.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
-node_modules/
+**/frontend/dist/
+**/frontend/node_modules/


### PR DESCRIPTION
This meant that when working locally `node_modules` were being copied into the docker image which resulted in build failures since the binaries were incompatible with the Docker image.