### PR TITLE
[DSI-8107] Fix attribute mapping in DTO

### DIFF
--- a/src/Dfe.SignIn.NodeApi.Client/Users/Models/GetUserStatusDtos.cs
+++ b/src/Dfe.SignIn.NodeApi.Client/Users/Models/GetUserStatusDtos.cs
@@ -5,7 +5,7 @@ namespace Dfe.SignIn.NodeApi.Client.Users.Models;
 
 internal sealed record GetUserStatusResponseDto
 {
-    [JsonPropertyName("id")]
+    [JsonPropertyName("sub")]
     public required Guid Id { get; init; }
 
     [JsonPropertyName("status")]

--- a/tests/Dfe.SignIn.NodeApi.Client.UnitTests/Users/GetUserStatusNodeRequesterTests.cs
+++ b/tests/Dfe.SignIn.NodeApi.Client.UnitTests/Users/GetUserStatusNodeRequesterTests.cs
@@ -34,7 +34,7 @@ public sealed class GetUserStatusNodeRequesterTests
             ["(GET) http://directories.localhost/users/by-entra-oid/d9079a36-ce78-4265-afa3-1c0751e42616"]
                 = new MappedResponse(HttpStatusCode.OK, /*lang=json,strict*/ """
                 {
-                    "id": "c97d2fc4-6951-487d-bbcd-87182e70ddce",
+                    "sub": "c97d2fc4-6951-487d-bbcd-87182e70ddce",
                     "status": 1
                 }
                 """),
@@ -73,7 +73,7 @@ public sealed class GetUserStatusNodeRequesterTests
             ["(GET) http://directories.localhost/users/jo.bradford@example.com"] =
                 new MappedResponse(HttpStatusCode.OK, /*lang=json,strict*/ """
                 {
-                    "id": "c97d2fc4-6951-487d-bbcd-87182e70ddce",
+                    "sub": "c97d2fc4-6951-487d-bbcd-87182e70ddce",
                     "status": 1
                 }
                 """)


### PR DESCRIPTION
Node API returns `sub` instead of `id` for this endpoint.