### PR TITLE
[DSI-8662] Add `LinkEntraUserToDsiUseCase` for InternalApi

### DIFF
--- a/src/Dfe.SignIn.Core.Contracts/Users/EntraAccountAlreadyLinkedToDifferentUserException.cs
+++ b/src/Dfe.SignIn.Core.Contracts/Users/EntraAccountAlreadyLinkedToDifferentUserException.cs
@@ -1,0 +1,52 @@
+using Dfe.SignIn.Base.Framework;
+
+namespace Dfe.SignIn.Core.Contracts.Users;
+
+/// <summary>
+/// The exception thrown when a requested Entra OID is already linked to a different DSI user account.
+/// </summary>
+public sealed class EntraAccountAlreadyLinkedToDifferentUserException : InteractionException
+{
+    /// <summary>
+    /// Creates an instance of the <see cref="EntraAccountAlreadyLinkedToDifferentUserException"/>.
+    /// </summary>
+    /// <param name="userId"> The ID of the DSI user that the Entra OID was intended to be linked to. </param>
+    /// <param name="entraOid">The Entra Object ID that is already linked to another user. </param>
+    /// <param name="existingUserId"> The ID of the DSI user account that the Entra OID is currently linked to.</param>
+    public static EntraAccountAlreadyLinkedToDifferentUserException FromUserIds(
+        Guid userId, Guid entraOid, Guid existingUserId) => new() {
+            UserId = userId,
+            EntraOid = entraOid,
+            ExistingUserId = existingUserId,
+        };
+
+    /// <inheritdoc/>
+    public EntraAccountAlreadyLinkedToDifferentUserException() { }
+
+    /// <inheritdoc/>
+    public EntraAccountAlreadyLinkedToDifferentUserException(string? message)
+        : base(message) { }
+
+    /// <inheritdoc/>
+    public EntraAccountAlreadyLinkedToDifferentUserException(string? message, Exception? innerException)
+        : base(message, innerException) { }
+
+    /// <summary>
+    /// Gets the DSI user ID that the Entra OID is intended to link to.
+    /// </summary>
+    [Persist]
+    public Guid UserId { get; private set; }
+
+    /// <summary>
+    /// Gets the Entra OID that needs to be linked to a DSI user.
+    /// </summary>
+    [Persist]
+    public Guid EntraOid { get; private set; }
+
+    /// <summary>
+    /// Gets the ID of the existing user that the Entra OID is currently linked to.
+    /// </summary>
+    [Persist]
+    public Guid ExistingUserId { get; private set; }
+}
+

--- a/src/Dfe.SignIn.Core.Contracts/Users/LinkEntraUserToDsi.cs
+++ b/src/Dfe.SignIn.Core.Contracts/Users/LinkEntraUserToDsi.cs
@@ -7,6 +7,9 @@ namespace Dfe.SignIn.Core.Contracts.Users;
 /// Represents a request to link an Entra user to DfE Sign-in.
 /// </summary>
 [AssociatedResponse(typeof(LinkEntraUserToDsiResponse))]
+[Throws(typeof(UserNotFoundException))]
+[Throws(typeof(UserAlreadyLinkedToEntraAccountException))]
+[Throws(typeof(EntraAccountAlreadyLinkedToDifferentUserException))]
 public sealed record LinkEntraUserToDsiRequest
 {
     /// <summary>
@@ -22,13 +25,15 @@ public sealed record LinkEntraUserToDsiRequest
     /// <summary>
     /// The first name of the user.
     /// </summary>
-    [MinLength(1)]
+    [Required]
+    [RegularExpression(StringPatterns.FirstNamePattern)]
     public required string FirstName { get; init; }
 
     /// <summary>
     /// The last name of the user.
     /// </summary>
-    [MinLength(1)]
+    [Required]
+    [RegularExpression(StringPatterns.LastNamePattern)]
     public required string LastName { get; init; }
 }
 

--- a/src/Dfe.SignIn.Core.Contracts/Users/UserAlreadyLinkedToEntraAccountException.cs
+++ b/src/Dfe.SignIn.Core.Contracts/Users/UserAlreadyLinkedToEntraAccountException.cs
@@ -1,0 +1,53 @@
+using Dfe.SignIn.Base.Framework;
+
+namespace Dfe.SignIn.Core.Contracts.Users;
+
+/// <summary>
+/// The exception thrown when a DSI user account is already linked to an Entra OID,
+/// but an attempt is made to link it to a different Entra OID.
+/// </summary>
+public sealed class UserAlreadyLinkedToEntraAccountException : InteractionException
+{
+    /// <summary>
+    /// Creates an instance of the <see cref="UserAlreadyLinkedToEntraAccountException"/>.
+    /// </summary>
+    /// <param name="userId">The DSI user Id.</param>
+    /// <param name="entraOid">The Entra Oid that the DSI user account is currently linked to.</param>
+    /// <param name="targetEntraId">The Entra Oid that the DSI user account was intended to be linked to.</param>
+    public static UserAlreadyLinkedToEntraAccountException FromUserIds(
+        Guid userId, Guid entraOid, Guid targetEntraId) => new() {
+            UserId = userId,
+            EntraOid = entraOid,
+            TargetEntraId = targetEntraId,
+        };
+
+    /// <inheritdoc/>
+    public UserAlreadyLinkedToEntraAccountException() { }
+
+    /// <inheritdoc/>
+    public UserAlreadyLinkedToEntraAccountException(string? message)
+        : base(message) { }
+
+    /// <inheritdoc/>
+    public UserAlreadyLinkedToEntraAccountException(string? message, Exception? innerException)
+        : base(message, innerException) { }
+
+    /// <summary>
+    /// The DSI user Id.
+    /// </summary>
+    [Persist]
+    public Guid UserId { get; private set; }
+
+    /// <summary>
+    /// The Entra Oid that the DSI user account is currently linked to.
+    /// </summary>
+    [Persist]
+    public Guid EntraOid { get; private set; }
+
+    /// <summary>
+    /// The Entra Oid that the DSI user account was intended to be linked to.
+    /// </summary>
+    [Persist]
+    public Guid TargetEntraId { get; private set; }
+}
+

--- a/src/Dfe.SignIn.Core.UseCases/Users/LinkEntraUserToDsiUseCase.cs
+++ b/src/Dfe.SignIn.Core.UseCases/Users/LinkEntraUserToDsiUseCase.cs
@@ -1,0 +1,87 @@
+using Dfe.SignIn.Base.Framework;
+using Dfe.SignIn.Core.Contracts.Audit;
+using Dfe.SignIn.Core.Contracts.Users;
+using Dfe.SignIn.Core.Entities.Directories;
+using Dfe.SignIn.Core.Interfaces.DataAccess;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dfe.SignIn.Core.UseCases.Users;
+
+/// <summary>
+/// Use case for linking an Entra user to a DfE Sign-in user.
+/// </summary>
+public sealed class LinkEntraUserToDsiUseCase(
+    IUnitOfWorkDirectories unitOfWork,
+    IInteractionDispatcher interaction,
+    TimeProvider timeProvider
+    ) : Interactor<LinkEntraUserToDsiRequest, LinkEntraUserToDsiResponse>
+{
+    /// <inheritdoc/>
+    public override async Task<LinkEntraUserToDsiResponse> InvokeAsync(
+        InteractionContext<LinkEntraUserToDsiRequest> context,
+        CancellationToken cancellationToken = default)
+    {
+        context.ThrowIfHasValidationErrors();
+
+        var user = await unitOfWork.Repository<UserEntity>()
+            .Where(x => x.Sub == context.Request.DsiUserId)
+            .SingleOrDefaultAsync(cancellationToken: cancellationToken)
+            ?? throw UserNotFoundException.FromUserId(context.Request.DsiUserId);
+
+        // Check if user is already linked to an Entra account; but a different one
+        if (user.EntraOid is Guid userEntraOid && userEntraOid != context.Request.EntraUserId) {
+            throw UserAlreadyLinkedToEntraAccountException.FromUserIds(
+                user.Sub, userEntraOid, context.Request.EntraUserId);
+        }
+
+        var existingEntraUser = await unitOfWork
+            .Repository<UserEntity>()
+            .Where(x => x.EntraOid == context.Request.EntraUserId)
+            .Select(x => new { x.Sub })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        // Check if the target Entra Oid has already been linked to a different user
+        if (existingEntraUser is not null && existingEntraUser.Sub != user.Sub) {
+            throw EntraAccountAlreadyLinkedToDifferentUserException.FromUserIds(
+                user.Sub, context.Request.EntraUserId, existingEntraUser.Sub);
+        }
+
+        bool nameUpdated = false;
+        bool entraAccountLinked = false;
+
+        if (user.FirstName != context.Request.FirstName) {
+            user.FirstName = context.Request.FirstName;
+            nameUpdated = true;
+        }
+        if (user.LastName != context.Request.LastName) {
+            user.LastName = context.Request.LastName;
+            nameUpdated = true;
+        }
+        if (user.EntraOid is null) {
+            user.EntraOid = context.Request.EntraUserId;
+            user.IsEntra = true;
+            user.EntraLinked = timeProvider.GetUtcNow().UtcDateTime;
+            entraAccountLinked = true;
+        }
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        if (nameUpdated) {
+            await interaction.DispatchAsync(new WriteToAuditRequest {
+                EventCategory = AuditEventCategoryNames.ChangeName,
+                Message = $"Successfully changed name to {user.FirstName} {user.LastName}",
+                UserId = user.Sub,
+            });
+        }
+
+        if (entraAccountLinked) {
+            await interaction.DispatchAsync(new WriteToAuditRequest {
+                EventCategory = AuditEventCategoryNames.Auth,
+                EventName = AuditAuthEventNames.LinkToExistingUser,
+                Message = $"Linked Entra account with existing DfE Sign-In user {user.Email}.",
+                UserId = user.Sub,
+            });
+        }
+
+        return new LinkEntraUserToDsiResponse();
+    }
+}

--- a/src/Dfe.SignIn.InternalApi/Configuration/UserUseCaseExtensions.cs
+++ b/src/Dfe.SignIn.InternalApi/Configuration/UserUseCaseExtensions.cs
@@ -32,6 +32,7 @@ public static class UserUseCaseExtensions
         services.AddInteractor<GetOrganisationsAssociatedWithUserUseCase>();
         services.AddInteractor<GetUserProfileUseCase>();
         services.AddInteractor<GetUserStatusUseCase>();
+        services.AddInteractor<LinkEntraUserToDsiUseCase>();
 
         services
             .Configure<BlockedEmailAddressOptions>(options => {

--- a/src/Dfe.SignIn.InternalApi/Endpoints/InteractionEndpoints.cs
+++ b/src/Dfe.SignIn.InternalApi/Endpoints/InteractionEndpoints.cs
@@ -57,6 +57,7 @@ public static partial class InteractionEndpoints
     public static void UseUserEndpoints(this WebApplication app)
     {
         app.Map<AutoLinkEntraUserToDsiRequest, AutoLinkEntraUserToDsiResponse>();
+        app.Map<LinkEntraUserToDsiRequest, LinkEntraUserToDsiResponse>();
         app.Map<ChangeJobTitleRequest, ChangeJobTitleResponse>();
         app.Map<CheckIsBlockedEmailAddressRequest, CheckIsBlockedEmailAddressResponse>();
         app.Map<GetOrganisationsAssociatedWithUserRequest, GetOrganisationsAssociatedWithUserResponse>();

--- a/src/Dfe.SignIn.InternalApi/Endpoints/InteractionEndpoints.cs
+++ b/src/Dfe.SignIn.InternalApi/Endpoints/InteractionEndpoints.cs
@@ -57,11 +57,11 @@ public static partial class InteractionEndpoints
     public static void UseUserEndpoints(this WebApplication app)
     {
         app.Map<AutoLinkEntraUserToDsiRequest, AutoLinkEntraUserToDsiResponse>();
-        app.Map<LinkEntraUserToDsiRequest, LinkEntraUserToDsiResponse>();
         app.Map<ChangeJobTitleRequest, ChangeJobTitleResponse>();
         app.Map<CheckIsBlockedEmailAddressRequest, CheckIsBlockedEmailAddressResponse>();
         app.Map<GetOrganisationsAssociatedWithUserRequest, GetOrganisationsAssociatedWithUserResponse>();
         app.Map<GetUserProfileRequest, GetUserProfileResponse>();
         app.Map<GetUserStatusRequest, GetUserStatusResponse>();
+        app.Map<LinkEntraUserToDsiRequest, LinkEntraUserToDsiResponse>();
     }
 }

--- a/tests/Dfe.SignIn.Core.UseCases.UnitTests/Users/LinkEntraUserToDsiUseCaseTests.cs
+++ b/tests/Dfe.SignIn.Core.UseCases.UnitTests/Users/LinkEntraUserToDsiUseCaseTests.cs
@@ -1,0 +1,257 @@
+using Dfe.SignIn.Core.Contracts.Audit;
+using Dfe.SignIn.Core.Contracts.Users;
+using Dfe.SignIn.Core.Entities.Directories;
+using Dfe.SignIn.Core.UseCases.Users;
+using Dfe.SignIn.Gateways.EntityFramework;
+using Moq.AutoMock;
+
+namespace Dfe.SignIn.Core.UseCases.UnitTests.Users;
+
+[TestClass]
+public sealed class LinkEntraUserToDsiUseCaseTests
+{
+    [TestMethod]
+    public Task Throws_WhenRequestIsInvalid()
+    {
+        return InteractionAssert.ThrowsWhenRequestIsInvalid<
+            LinkEntraUserToDsiRequest,
+            LinkEntraUserToDsiUseCase
+        >();
+    }
+
+    private static readonly Guid UserIdMatchingDsiUserId = Guid.Parse("3ed6826f-6854-4adf-b65f-5b2ace7c8691");
+    private static readonly Guid UserIdMatchingEntraOid = Guid.Parse("74f539fa-5de2-4b15-b983-24ca9612b7cb");
+    private static readonly Guid UserEntraOid = Guid.Parse("ecf31b2d-03e8-4f00-9035-32d2dd4a9ed3");
+    private static readonly Guid EntraOid = Guid.Parse("3ed6826f-6854-4adf-b65f-5b2ace7c8693");
+
+    private static async Task<DbDirectoriesContext> SetupFakeDatabaseAsync(AutoMocker autoMocker)
+    {
+
+        var ctx = autoMocker.UseInMemoryDirectoriesDb();
+        ctx.Users.AddRange(new UserEntity {
+            Sub = UserIdMatchingDsiUserId,
+            IsEntra = false,
+            FirstName = "Alex",
+            LastName = "Johnson",
+            Email = "alex.johnson@example.com",
+            Password = "",
+            Salt = "",
+            Status = 1,
+            UpdatedAt = DateTime.Now
+        },
+            new UserEntity {
+                Sub = UserIdMatchingEntraOid,
+                IsEntra = true,
+                FirstName = "Bob",
+                LastName = "Johnson",
+                Email = "bob.johnson@example.com",
+                EntraOid = UserEntraOid,
+                Password = "",
+                Salt = "",
+                Status = 1,
+                EntraLinked = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                UpdatedAt = DateTime.Now
+            });
+
+        await ctx.SaveChangesAsync();
+        return ctx;
+    }
+
+    private static async Task<(LinkEntraUserToDsiUseCase Interactor, DbDirectoriesContext Db, List<WriteToAuditRequest> Audit)>
+        SetupAsync()
+    {
+        var autoMocker = new AutoMocker();
+
+        autoMocker.Use<TimeProvider>(
+        new MockTimeProvider(new DateTimeOffset(2025, 11, 18, 17, 56, 45, TimeSpan.Zero)));
+        var db = await SetupFakeDatabaseAsync(autoMocker);
+
+        var interactor = autoMocker.CreateInstance<LinkEntraUserToDsiUseCase>();
+
+        var capturedAudit = new List<WriteToAuditRequest>();
+        autoMocker.CaptureRequest<WriteToAuditRequest>(capturedAudit.Add);
+
+        return (interactor, db, capturedAudit);
+    }
+
+    [TestMethod]
+    public async Task Throws_WhenUserDoesNotExistByDsiUserId()
+    {
+        var (interactor, _, _) = await SetupAsync();
+        Guid nonExistentUserId = Guid.Parse("3ed6826f-6854-4adf-b65f-5b2ace7c8699");
+
+        var exception = await Assert.ThrowsExactlyAsync<UserNotFoundException>(async () => {
+            await interactor.InvokeAsync(
+                new LinkEntraUserToDsiRequest {
+                    DsiUserId = nonExistentUserId,
+                    EntraUserId = UserEntraOid,
+                    FirstName = "Jane",
+                    LastName = "Doe"
+                });
+        });
+
+        Assert.AreEqual(nonExistentUserId, exception.UserId);
+    }
+
+    [TestMethod]
+    public async Task Throws_WhenEntraAccountAlreadyLinkedToDifferentUser()
+    {
+        var autoMocker = new AutoMocker();
+        await SetupFakeDatabaseAsync(autoMocker);
+
+        var interactor = autoMocker.CreateInstance<LinkEntraUserToDsiUseCase>();
+
+        var exception = await Assert.ThrowsExactlyAsync<EntraAccountAlreadyLinkedToDifferentUserException>(async () => {
+            await interactor.InvokeAsync(
+                new LinkEntraUserToDsiRequest {
+                    DsiUserId = UserIdMatchingDsiUserId,
+                    EntraUserId = UserEntraOid,
+                    FirstName = "Alex",
+                    LastName = "Johnson"
+                });
+        });
+
+        Assert.AreEqual(UserIdMatchingDsiUserId, exception.UserId);
+        Assert.AreEqual(UserEntraOid, exception.EntraOid);
+        Assert.AreEqual(UserIdMatchingEntraOid, exception.ExistingUserId);
+    }
+
+    [TestMethod]
+    public async Task Throws_WhenUserAlreadyLinkedToAnEntraAccount()
+    {
+        var autoMocker = new AutoMocker();
+        await SetupFakeDatabaseAsync(autoMocker);
+
+        var interactor = autoMocker.CreateInstance<LinkEntraUserToDsiUseCase>();
+
+        var exception = await Assert.ThrowsExactlyAsync<UserAlreadyLinkedToEntraAccountException>(async () => {
+            await interactor.InvokeAsync(
+                new LinkEntraUserToDsiRequest {
+                    DsiUserId = UserIdMatchingEntraOid,
+                    EntraUserId = EntraOid,
+                    FirstName = "Alex",
+                    LastName = "Johnson"
+                });
+        });
+
+        Assert.AreEqual(UserIdMatchingEntraOid, exception.UserId);
+        Assert.AreEqual(UserEntraOid, exception.EntraOid);
+        Assert.AreEqual(EntraOid, exception.TargetEntraId);
+    }
+
+    [TestMethod]
+    public async Task LinkEntraUserToDsi_WhenNotPreviouslyLinkedToEntra()
+    {
+        var (interactor, db, _) = await SetupAsync();
+
+        var response = await interactor.InvokeAsync(
+            new LinkEntraUserToDsiRequest {
+                DsiUserId = UserIdMatchingDsiUserId,
+                EntraUserId = EntraOid,
+                FirstName = "Alex",
+                LastName = "Johnson"
+            }
+        );
+        var user = db.Users.Single(x => x.Sub == UserIdMatchingDsiUserId);
+
+        Assert.IsNotNull(user);
+        Assert.AreEqual(EntraOid, user.EntraOid);
+        Assert.IsTrue(user.IsEntra);
+        Assert.IsNotNull(user.EntraLinked);
+        Assert.AreEqual(new DateTime(2025, 11, 18, 17, 56, 45, DateTimeKind.Utc), user.EntraLinked);
+        Assert.AreEqual("Alex", user.FirstName);
+        Assert.AreEqual("Johnson", user.LastName);
+
+        Assert.IsInstanceOfType(response, typeof(LinkEntraUserToDsiResponse));
+    }
+
+    [TestMethod]
+    public async Task WritesToAudit_WhenNotPreviouslyLinkedToEntra()
+    {
+        var (interactor, db, capturedAudit) = await SetupAsync();
+
+        var response = await interactor.InvokeAsync(
+            new LinkEntraUserToDsiRequest {
+                DsiUserId = UserIdMatchingDsiUserId,
+                EntraUserId = EntraOid,
+                FirstName = "Alex",
+                LastName = "Johnson"
+            }
+        );
+        var user = db.Users.Single(x => x.Sub == UserIdMatchingDsiUserId);
+
+        Assert.HasCount(1, capturedAudit);
+        var audit = capturedAudit.Single();
+
+        Assert.AreEqual(AuditEventCategoryNames.Auth, audit.EventCategory);
+        Assert.AreEqual(AuditAuthEventNames.LinkToExistingUser, audit.EventName);
+        Assert.AreEqual($"Linked Entra account with existing DfE Sign-In user {user.Email}.", audit.Message);
+
+        Assert.IsInstanceOfType(response, typeof(LinkEntraUserToDsiResponse));
+    }
+
+    [TestMethod]
+    public async Task UpdatesNameCorrectly_WhenNotLinked()
+    {
+        var (interactor, db, capturedAudit) = await SetupAsync();
+
+        var response = await interactor.InvokeAsync(
+            new LinkEntraUserToDsiRequest {
+                DsiUserId = UserIdMatchingDsiUserId,
+                EntraUserId = EntraOid,
+                FirstName = "John",
+                LastName = "Doe"
+            }
+        );
+
+        var user = db.Users.Single(x => x.Sub == UserIdMatchingDsiUserId);
+
+        var audits = capturedAudit.ToList();
+        var changeNameAudit = audits.Single(a => a.EventCategory == AuditEventCategoryNames.ChangeName);
+        var authAudit = audits.Single(a => a.EventCategory == AuditEventCategoryNames.Auth);
+
+        Assert.AreEqual("John", user.FirstName);
+        Assert.AreEqual("Doe", user.LastName);
+        Assert.AreEqual(EntraOid, user.EntraOid);
+        Assert.IsTrue(user.IsEntra);
+        Assert.IsNotNull(user.EntraLinked);
+
+        Assert.HasCount(2, audits);
+        Assert.AreEqual($"Successfully changed name to {user.FirstName} {user.LastName}", changeNameAudit.Message);
+        Assert.AreEqual(AuditAuthEventNames.LinkToExistingUser, authAudit.EventName);
+        Assert.AreEqual($"Linked Entra account with existing DfE Sign-In user {user.Email}.", authAudit.Message);
+
+        Assert.IsInstanceOfType(response, typeof(LinkEntraUserToDsiResponse));
+
+    }
+
+    [TestMethod]
+    public async Task UpdatesNameCorrectly_WhenAlreadyLinked()
+    {
+        var (interactor, db, capturedAudit) = await SetupAsync();
+
+        var response = await interactor.InvokeAsync(
+            new LinkEntraUserToDsiRequest {
+                DsiUserId = UserIdMatchingEntraOid,
+                EntraUserId = UserEntraOid,
+                FirstName = "John",
+                LastName = "Doe"
+            }
+        );
+        var user = db.Users.Single(x => x.Sub == UserIdMatchingEntraOid);
+        var audit = capturedAudit.Single();
+
+        Assert.IsNotNull(user);
+        Assert.AreEqual(UserEntraOid, user.EntraOid);
+        Assert.IsTrue(user.IsEntra);
+        Assert.IsNotNull(user.EntraLinked);
+        Assert.AreEqual(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), user.EntraLinked);
+        Assert.AreEqual("John", user.FirstName);
+        Assert.AreEqual("Doe", user.LastName);
+
+        Assert.AreEqual(AuditEventCategoryNames.ChangeName, audit.EventCategory);
+        Assert.AreEqual($"Successfully changed name to {user.FirstName} {user.LastName}", audit.Message);
+
+        Assert.IsInstanceOfType(response, typeof(LinkEntraUserToDsiResponse));
+    }
+}


### PR DESCRIPTION
### Summary
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-8662

### Changes

- Added `LinkEntraUserToDsiUseCase` for InternalApi ensuring test coverage.
- Added `UserAlreadyLinkedToEntraAccountException` and  `EntraAccountAlreadyLinkedToDifferentUserException` exceptions
- Updated `LinkEntraUserToDsiResponse` contract to include `LinkEntraUserToDsiResponse`, `UserAlreadyLinkedToEntraAccountException` and  `EntraAccountAlreadyLinkedToDifferentUserException` exceptions
- Updated `LinkEntraUserToDsiResponse` contract to use first name and last name validation
