### PR TITLE
Use 'DirectorySeparatorChar' in msbuild props file for compatibility with Windows

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <NuGetAuditLevel>moderate</NuGetAuditLevel>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('src/'))">
+  <PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('src$(DirectorySeparatorChar)'))">
     <!-- Required for NuGet packages and Swagger. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
MSBuild property file was using a hard coded '/' character which worked okay on MacOS and Linux (GitHub workflows) but not on Windows machines.

This PR addresses the issue by using a constant provided by MSBuild which varies as needes by platform.