### PR TITLE
Fix broken unit tests owing to ambiguous ClaimsIdentity reference

### DIFF
--- a/tests/Dfe.SignIn.PublicApi.Client.AspNetCore.UnitTests/ActiveOrganisationSessionProviderTests.cs
+++ b/tests/Dfe.SignIn.PublicApi.Client.AspNetCore.UnitTests/ActiveOrganisationSessionProviderTests.cs
@@ -31,7 +31,7 @@ public sealed class ActiveOrganisationSessionProviderTests
         mockAbstractionContext.Setup(x => x.Inner).Returns(mockContext.Object);
 
         var user = new ClaimsPrincipal(
-            new ClaimsIdentity([
+            new ClaimsIdentity((IEnumerable<Claim>?)[
                 new(DsiClaimTypes.SessionId, FakeSessionId),
                 new(DsiClaimTypes.UserId, FakeUserId),
             ])

--- a/tests/Dfe.SignIn.Web.Profile.UnitTests/Services/SelectAssociatedAccountHelperTests.cs
+++ b/tests/Dfe.SignIn.Web.Profile.UnitTests/Services/SelectAssociatedAccountHelperTests.cs
@@ -226,7 +226,7 @@ public sealed class SelectAssociatedAccountHelperTests
     {
         var autoMocker = new AutoMocker();
 
-        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity([
+        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity((IEnumerable<Claim>?)[
             new("dsi_user_id", "c59d1905-3a44-4e2b-8a32-3859a13c0c4f"),
         ]));
 
@@ -257,7 +257,7 @@ public sealed class SelectAssociatedAccountHelperTests
     {
         var autoMocker = new AutoMocker();
 
-        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity([
+        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity((IEnumerable<Claim>?)[
             new("dsi_user_id", "15eb0a65-2d08-4f96-8dc9-9d77798e6c54"),
         ]));
 
@@ -294,7 +294,7 @@ public sealed class SelectAssociatedAccountHelperTests
     {
         var autoMocker = new AutoMocker();
 
-        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity([
+        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity((IEnumerable<Claim>?)[
             new("dsi_user_id", "15eb0a65-2d08-4f96-8dc9-9d77798e6c54"),
         ]));
 
@@ -321,7 +321,7 @@ public sealed class SelectAssociatedAccountHelperTests
     {
         var autoMocker = new AutoMocker();
 
-        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity([
+        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity((IEnumerable<Claim>?)[
             new("dsi_user_id", "15eb0a65-2d08-4f96-8dc9-9d77798e6c54"),
         ]));
 
@@ -445,7 +445,7 @@ public sealed class SelectAssociatedAccountHelperTests
     {
         var autoMocker = new AutoMocker();
 
-        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity([
+        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity((IEnumerable<Claim>?)[
             new("dsi_user_id", "ffa39281-b388-4edc-998e-afb58a63f28a"),
         ]));
 
@@ -471,7 +471,7 @@ public sealed class SelectAssociatedAccountHelperTests
         var autoMocker = new AutoMocker();
         autoMocker.Use<TimeProvider>(new MockTimeProvider(new DateTimeOffset(2025, 11, 19, 14, 11, 43, TimeSpan.Zero)));
 
-        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity([
+        var fakeUser = new ClaimsPrincipal(new ClaimsIdentity((IEnumerable<Claim>?)[
             new("dsi_user_id", "15eb0a65-2d08-4f96-8dc9-9d77798e6c54"),
         ]));
 

--- a/tests/Dfe.SignIn.WebFramework.Mvc.UnitTests/ClaimsPrincipalExtensionsTests.cs
+++ b/tests/Dfe.SignIn.WebFramework.Mvc.UnitTests/ClaimsPrincipalExtensionsTests.cs
@@ -18,7 +18,7 @@ public sealed class ClaimsPrincipalExtensionsTests
     public void TryGetUserId_ReturnsTrue_WhenClaimIsPresent()
     {
         var principal = new ClaimsPrincipal([
-            new([
+            new ClaimsIdentity((IEnumerable<Claim>?)[
                 new(ClaimTypes.NameIdentifier, "286101e9-a2dd-4894-bb3b-aefa8ea60ecd")
             ])
         ]);
@@ -62,7 +62,7 @@ public sealed class ClaimsPrincipalExtensionsTests
     public void GetUserId_ReturnsUserId()
     {
         var principal = new ClaimsPrincipal([
-            new([
+            new ClaimsIdentity((IEnumerable<Claim>?)[
                 new(ClaimTypes.NameIdentifier, "286101e9-a2dd-4894-bb3b-aefa8ea60ecd")
             ])
         ]);


### PR DESCRIPTION
Running dotnet build was returning compiler errors:

_The call is ambiguous between the following methods or properties: 'ClaimsIdentity.ClaimsIdentity(IEnumerable<Claim>?)' and 'ClaimsIdentity.Claim sIdentity(string?)'_

Its unclear why the error occurs as the code compiles fine on other developer machines. The fix is to explicitly define the type .

Replace 
**new ClaimsIdentity([**

With
**new ClaimsIdentity((IEnumerable<Claim>?)[**

After making changes, code compiles and unit tests pass.
