### PR TITLE
[DSI-8564] Update custom.css based on latest documentation

### DIFF
--- a/frontend/external-id/styles/custom.css
+++ b/frontend/external-id/styles/custom.css
@@ -33,8 +33,10 @@ body {
 }
 
 /**
-  * <a> selectors will be phased out by Microsoft in a future update;
-  * review and remove if no longer needed.
+  * HTML <a> selectors remain listed as supported in the Microsoft Entra CSS
+  * reference documentation. However, Microsoft recommends using .ext-link for
+  * internal navigation links. These selectors may still be stripped in some
+  * tenant configurations.
 */
 
 a {
@@ -72,6 +74,10 @@ a:link {
   color: #1d70b8 !important;
 }
 
+/**
+  * NOTE: a:visited is not listed in the Microsoft Entra CSS documentation
+  * and may be stripped when uploaded to the Entra portal.
+  */
 a:visited {
   color: #4c2c92 !important;
 }
@@ -82,6 +88,18 @@ a:hover {
 
 a:active,
 a:focus {
+  color: #0b0c0c !important;
+}
+
+a:focus:hover {
+  outline: 3px solid transparent;
+  background-color: #fd0;
+  box-shadow:
+    0 -2px #fd0,
+    0 4px #0b0c0c;
+  text-decoration: none;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
   color: #0b0c0c !important;
 }
 
@@ -116,6 +134,11 @@ a:focus {
   box-decoration-break: clone;
 }
 
+/**
+  * NOTE: .ext-link:link, .ext-link:visited, and .ext-link:active are not
+  * explicitly listed in the Microsoft Entra CSS documentation and may be
+  * stripped when uploaded to the Entra portal.
+  */
 .ext-link:link {
   color: #1d70b8 !important;
 }
@@ -130,6 +153,18 @@ a:focus {
 
 .ext-link:active,
 .ext-link:focus {
+  color: #0b0c0c !important;
+}
+
+.ext-link:focus:hover {
+  outline: 3px solid transparent;
+  background-color: #fd0;
+  box-shadow:
+    0 -2px #fd0,
+    0 4px #0b0c0c;
+  text-decoration: none;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
   color: #0b0c0c !important;
 }
 
@@ -155,7 +190,7 @@ a:focus {
   background-color: #f3f2f1 !important;
 }
 
-.ext-footer-content {
+.ext-footer-links {
   color: inherit !important;
   font-size: inherit !important;
 }
@@ -215,6 +250,13 @@ a:focus {
 }
 
 .ext-button.ext-primary:focus {
+  border-color: #ffdd00;
+  color: #0b0c0c;
+  background-color: #ffdd00;
+  box-shadow: 0 2px 0 #0b0c0c;
+}
+
+.ext-button.ext-primary:focus:hover {
   border-color: #ffdd00;
   color: #0b0c0c;
   background-color: #ffdd00;
@@ -290,6 +332,13 @@ a:focus {
   box-shadow: 0 2px 0 #0b0c0c;
 }
 
+.ext-button.ext-secondary:focus:hover {
+  border-color: #ffdd00;
+  color: #0b0c0c;
+  background-color: #ffdd00;
+  box-shadow: 0 2px 0 #0b0c0c;
+}
+
 .ext-button.ext-secondary::before {
   content: "";
   display: block;
@@ -327,6 +376,21 @@ a:focus {
 }
 
 .ext-input.ext-text-box:focus {
+  outline: 3px solid #fd0;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 2px;
+}
+
+.ext-input.ext-text-box.ext-has-error {
+  border-color: #d4351c;
+  border-width: 4px;
+}
+
+.ext-input.ext-text-box:hover {
+  border-color: #0b0c0c;
+}
+
+.ext-input.ext-text-box:focus:hover {
   outline: 3px solid #fd0;
   outline-offset: 0;
   box-shadow: inset 0 0 0 2px;


### PR DESCRIPTION
Here's a walkthrough of each change and the reasoning behind it:

What is this file for?
Microsoft Entra (the identity provider behind the DfE Sign-in login screens) lets you upload a custom CSS file to make the login pages look like GOV.UK. The catch is that Microsoft only allows specific CSS selectors — anything outside their approved list gets silently stripped out when you upload the file. So staying in sync with their documentation matters.

1. Stale comment fix
The old comment said <a> selectors would "be phased out". The docs (updated Jan 2026) still list them as valid. Leaving an incorrect comment in place causes confusion — a future developer might remove all the a styles thinking they're obsolete when they're not.

2. Adding :focus:hover variants
The docs list a:focus:hover, .ext-link:focus:hover, .ext-button.ext-primary:focus:hover, and .ext-button.ext-secondary:focus:hover as distinct supported selectors.

Why does this matter? CSS specificity. When a user tabs to a button (:focus) and then moves their mouse over it (:hover), both pseudo-classes apply simultaneously. Without an explicit :focus:hover rule, the browser will use whichever of :focus or :hover has higher specificity — which may produce unexpected visual results like the yellow focus ring disappearing when the cursor drifts over the button.

3. New text box selectors
The docs now define three additional text box states that weren't in the file:

.ext-input.ext-text-box.ext-has-error — Entra applies this class when a field fails validation. Without styling it, the error state has no visual feedback beyond what Entra provides by default, which won't match GOV.UK styling.
.ext-input.ext-text-box:hover — an explicit border colour on hover, so the field gives clear visual feedback when the user moves their cursor over it.
.ext-input.ext-text-box:focus:hover — same reasoning as the buttons above; prevents the focus ring from being overridden by the hover rule.

4. Renaming .ext-footer-content → .ext-footer-links
The old selector .ext-footer-content no longer appears anywhere in the updated documentation. The docs now define .ext-footer-links as the selector for the links area inside the footer.

This is the most impactful change practically — since Microsoft strips unrecognised selectors, .ext-footer-content styles would have been silently dropped on upload, meaning the footer link styles weren't actually being applied at all. Renaming it to the documented .ext-footer-links means they will be applied.

5. Flagging undocumented selectors with comments
Selectors like a:visited, .ext-link:visited, .ext-link:link, and .ext-link:active aren't listed in the docs. This doesn't necessarily mean they're broken, but it's a risk — Microsoft might strip them. Rather than delete them (which would break visited-link colouring), a /* NOTE */ comment was added so the next developer knows these are unverified and should be tested after uploading.
