### PR TITLE
DSI-8690 Fix: Name validation pattern rejects compound surnames with space-hyphen-space

### DIFF
--- a/src/Dfe.SignIn.Core.Contracts/StringPatterns.cs
+++ b/src/Dfe.SignIn.Core.Contracts/StringPatterns.cs
@@ -32,8 +32,7 @@ public static partial class StringPatterns
     /// </returns>
     public static string? GetExampleValue(string? pattern)
     {
-        if (pattern is null)
-        {
+        if (pattern is null) {
             return null;
         }
 

--- a/src/Dfe.SignIn.Core.Contracts/StringPatterns.cs
+++ b/src/Dfe.SignIn.Core.Contracts/StringPatterns.cs
@@ -32,7 +32,8 @@ public static partial class StringPatterns
     /// </returns>
     public static string? GetExampleValue(string? pattern)
     {
-        if (pattern is null) {
+        if (pattern is null)
+        {
             return null;
         }
 
@@ -41,7 +42,7 @@ public static partial class StringPatterns
         return value;
     }
 
-    private const string NamePattern = @"[\p{L}\p{N}_][\p{L}\p{N}_'-]*( [\p{L}\p{N}][\p{L}\p{N} _'-]*)*";
+    private const string NamePattern = @"[\p{L}\p{N}_][\p{L}\p{N}_'-]*( (?:-\s*)?[\p{L}\p{N}][\p{L}\p{N} _'-]*)*";
 
     /// <summary>
     /// Regular expression pattern which can be used to verify the first name of a person.

--- a/src/Dfe.SignIn.Fn.AuthExtensions/OnTokenIssuanceStart/TokenIssuanceStartHandler.cs
+++ b/src/Dfe.SignIn.Fn.AuthExtensions/OnTokenIssuanceStart/TokenIssuanceStartHandler.cs
@@ -27,8 +27,7 @@ public sealed class TokenIssuanceStartHandler(
         @event.Validate();
 
         var checkLinkedResponse = await interaction.DispatchAsync(
-            new AutoLinkEntraUserToDsiRequest
-            {
+            new AutoLinkEntraUserToDsiRequest {
                 EntraUserId = @event.Data.AuthenticationContext.User.Id,
                 EmailAddress = @event.Data.AuthenticationContext.User.Mail.Trim(),
                 FirstName = @event.Data.AuthenticationContext.User.GivenName.Trim(),
@@ -36,10 +35,8 @@ public sealed class TokenIssuanceStartHandler(
             }
         ).To<AutoLinkEntraUserToDsiResponse>();
 
-        return ResponseAction(new ProvideClaimsForTokenAction
-        {
-            Claims = new()
-            {
+        return ResponseAction(new ProvideClaimsForTokenAction {
+            Claims = new() {
                 [DsiClaimTypes.UserId] = checkLinkedResponse.UserId.ToString(),
             },
         });
@@ -47,10 +44,8 @@ public sealed class TokenIssuanceStartHandler(
 
     private static OkObjectResult ResponseAction(IResponseAction action)
     {
-        return new OkObjectResult(new ResponseObject
-        {
-            Data = new TokenIssuanceStartEventResponseData
-            {
+        return new OkObjectResult(new ResponseObject {
+            Data = new TokenIssuanceStartEventResponseData {
                 Actions = [action],
             },
         });

--- a/src/Dfe.SignIn.Fn.AuthExtensions/OnTokenIssuanceStart/TokenIssuanceStartHandler.cs
+++ b/src/Dfe.SignIn.Fn.AuthExtensions/OnTokenIssuanceStart/TokenIssuanceStartHandler.cs
@@ -27,16 +27,19 @@ public sealed class TokenIssuanceStartHandler(
         @event.Validate();
 
         var checkLinkedResponse = await interaction.DispatchAsync(
-            new AutoLinkEntraUserToDsiRequest {
+            new AutoLinkEntraUserToDsiRequest
+            {
                 EntraUserId = @event.Data.AuthenticationContext.User.Id,
-                EmailAddress = @event.Data.AuthenticationContext.User.Mail,
-                FirstName = @event.Data.AuthenticationContext.User.GivenName,
-                LastName = @event.Data.AuthenticationContext.User.Surname,
+                EmailAddress = @event.Data.AuthenticationContext.User.Mail.Trim(),
+                FirstName = @event.Data.AuthenticationContext.User.GivenName.Trim(),
+                LastName = @event.Data.AuthenticationContext.User.Surname.Trim(),
             }
         ).To<AutoLinkEntraUserToDsiResponse>();
 
-        return ResponseAction(new ProvideClaimsForTokenAction {
-            Claims = new() {
+        return ResponseAction(new ProvideClaimsForTokenAction
+        {
+            Claims = new()
+            {
                 [DsiClaimTypes.UserId] = checkLinkedResponse.UserId.ToString(),
             },
         });
@@ -44,8 +47,10 @@ public sealed class TokenIssuanceStartHandler(
 
     private static OkObjectResult ResponseAction(IResponseAction action)
     {
-        return new OkObjectResult(new ResponseObject {
-            Data = new TokenIssuanceStartEventResponseData {
+        return new OkObjectResult(new ResponseObject
+        {
+            Data = new TokenIssuanceStartEventResponseData
+            {
                 Actions = [action],
             },
         });

--- a/tests/Dfe.SignIn.Core.Contracts.UnitTests/StringPatternsTests.cs
+++ b/tests/Dfe.SignIn.Core.Contracts.UnitTests/StringPatternsTests.cs
@@ -56,9 +56,12 @@ public sealed class StringPatternsTests
     [DataRow("_Test", true)]
     [DataRow("Alex Johnson", true)]
     [DataRow("Alex-bob O'John-son", true)]
+    [DataRow("MAY - FINNEGAN", true)]
+    [DataRow("May - Finnegan", true)]
     [DataRow("", false)]
     [DataRow(" ", false)]
     [DataRow(" Bob ", false)]
+    [DataRow("MAY -", false)]
     public void LastNameRegex_WorksAsExpected(string input, bool expectedResult)
     {
         bool result = StringPatterns.LastNameRegex().IsMatch(input);

--- a/tests/Dfe.SignIn.Fn.AuthExtensions.UnitTests/TokenIssuanceStartHandlerTests.cs
+++ b/tests/Dfe.SignIn.Fn.AuthExtensions.UnitTests/TokenIssuanceStartHandlerTests.cs
@@ -10,14 +10,18 @@ namespace Dfe.SignIn.Fn.AuthExtensions.UnitTests;
 [TestClass]
 public class TokenIssuanceStartHandlerTests
 {
-    private static readonly TokenIssuanceStartEvent FakeEvent = new() {
+    private static readonly TokenIssuanceStartEvent FakeEvent = new()
+    {
         Type = "microsoft.graph.authenticationEvent.tokenIssuanceStart",
-        Data = new() {
+        Data = new()
+        {
             Type = "microsoft.graph.onTokenIssuanceStartCalloutData",
             TenantId = new Guid("2b01ae60-a8c3-4a99-9be3-a981e2861c35"),
-            AuthenticationContext = new() {
+            AuthenticationContext = new()
+            {
                 CorrelationId = "6d75195d-b584-429f-86cf-7a3046306f03",
-                User = new() {
+                User = new()
+                {
                     Id = new Guid("21892c65-88df-4268-b025-d06f51c52404"),
                     Mail = "jo.bradford@example.com",
                     DisplayName = "BRADFORD, Jo",
@@ -39,7 +43,8 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
+        {
             Type = eventType,
         });
 
@@ -57,8 +62,10 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
-            Data = FakeEvent.Data with {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
+        {
+            Data = FakeEvent.Data with
+            {
                 Type = calloutDataType,
             },
         });
@@ -74,10 +81,14 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
-            Data = FakeEvent.Data with {
-                AuthenticationContext = FakeEvent.Data.AuthenticationContext with {
-                    User = FakeEvent.Data.AuthenticationContext.User with {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
+        {
+            Data = FakeEvent.Data with
+            {
+                AuthenticationContext = FakeEvent.Data.AuthenticationContext with
+                {
+                    User = FakeEvent.Data.AuthenticationContext.User with
+                    {
                         Mail = "abc",
                     },
                 },
@@ -96,10 +107,14 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
-            Data = FakeEvent.Data with {
-                AuthenticationContext = FakeEvent.Data.AuthenticationContext with {
-                    User = FakeEvent.Data.AuthenticationContext.User with {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
+        {
+            Data = FakeEvent.Data with
+            {
+                AuthenticationContext = FakeEvent.Data.AuthenticationContext with
+                {
+                    User = FakeEvent.Data.AuthenticationContext.User with
+                    {
                         GivenName = "",
                     },
                 },
@@ -118,10 +133,14 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
-            Data = FakeEvent.Data with {
-                AuthenticationContext = FakeEvent.Data.AuthenticationContext with {
-                    User = FakeEvent.Data.AuthenticationContext.User with {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
+        {
+            Data = FakeEvent.Data with
+            {
+                AuthenticationContext = FakeEvent.Data.AuthenticationContext with
+                {
+                    User = FakeEvent.Data.AuthenticationContext.User with
+                    {
                         Surname = "",
                     },
                 },
@@ -140,13 +159,15 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
 
         autoMocker.MockResponse(
-            new AutoLinkEntraUserToDsiRequest {
+            new AutoLinkEntraUserToDsiRequest
+            {
                 EntraUserId = new Guid("21892c65-88df-4268-b025-d06f51c52404"),
                 EmailAddress = "jo.bradford@example.com",
                 FirstName = "Jo",
                 LastName = "Bradford",
             },
-            new AutoLinkEntraUserToDsiResponse {
+            new AutoLinkEntraUserToDsiResponse
+            {
                 UserId = new Guid("d5ba1f44-1400-4c98-b834-5d5ba5b98995"),
             }
         );
@@ -154,6 +175,53 @@ public class TokenIssuanceStartHandlerTests
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
         var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent);
+
+        var result = await handler.Run(fakeRequest);
+
+        var okResult = TypeAssert.IsType<OkObjectResult>(result);
+        var response = TypeAssert.IsType<ResponseObject>(okResult.Value);
+        var data = TypeAssert.IsType<TokenIssuanceStartEventResponseData>(response.Data);
+        Assert.HasCount(1, data.Actions);
+        var provideClaimsAction = TypeAssert.IsType<ProvideClaimsForTokenAction>(data.Actions[0]);
+        Assert.AreEqual("d5ba1f44-1400-4c98-b834-5d5ba5b98995", provideClaimsAction.Claims[DsiClaimTypes.UserId]);
+    }
+
+    [TestMethod]
+    public async Task AutomaticallyLinkEntraUserToDsi_TrimsUserAttributesBeforeDispatch()
+    {
+        var autoMocker = new AutoMocker();
+
+        autoMocker.MockResponse(
+            new AutoLinkEntraUserToDsiRequest
+            {
+                EntraUserId = new Guid("21892c65-88df-4268-b025-d06f51c52404"),
+                EmailAddress = "jo.bradford@example.com",
+                FirstName = "Jo",
+                LastName = "MAY - FINNEGAN",
+            },
+            new AutoLinkEntraUserToDsiResponse
+            {
+                UserId = new Guid("d5ba1f44-1400-4c98-b834-5d5ba5b98995"),
+            }
+        );
+
+        var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
+
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
+        {
+            Data = FakeEvent.Data with
+            {
+                AuthenticationContext = FakeEvent.Data.AuthenticationContext with
+                {
+                    User = FakeEvent.Data.AuthenticationContext.User with
+                    {
+                        Mail = "jo.bradford@example.com",
+                        GivenName = " Jo ",
+                        Surname = " MAY - FINNEGAN ",
+                    },
+                },
+            },
+        });
 
         var result = await handler.Run(fakeRequest);
 

--- a/tests/Dfe.SignIn.Fn.AuthExtensions.UnitTests/TokenIssuanceStartHandlerTests.cs
+++ b/tests/Dfe.SignIn.Fn.AuthExtensions.UnitTests/TokenIssuanceStartHandlerTests.cs
@@ -10,18 +10,14 @@ namespace Dfe.SignIn.Fn.AuthExtensions.UnitTests;
 [TestClass]
 public class TokenIssuanceStartHandlerTests
 {
-    private static readonly TokenIssuanceStartEvent FakeEvent = new()
-    {
+    private static readonly TokenIssuanceStartEvent FakeEvent = new() {
         Type = "microsoft.graph.authenticationEvent.tokenIssuanceStart",
-        Data = new()
-        {
+        Data = new() {
             Type = "microsoft.graph.onTokenIssuanceStartCalloutData",
             TenantId = new Guid("2b01ae60-a8c3-4a99-9be3-a981e2861c35"),
-            AuthenticationContext = new()
-            {
+            AuthenticationContext = new() {
                 CorrelationId = "6d75195d-b584-429f-86cf-7a3046306f03",
-                User = new()
-                {
+                User = new() {
                     Id = new Guid("21892c65-88df-4268-b025-d06f51c52404"),
                     Mail = "jo.bradford@example.com",
                     DisplayName = "BRADFORD, Jo",
@@ -43,8 +39,7 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
-        {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
             Type = eventType,
         });
 
@@ -62,10 +57,8 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
-        {
-            Data = FakeEvent.Data with
-            {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
+            Data = FakeEvent.Data with {
                 Type = calloutDataType,
             },
         });
@@ -81,14 +74,10 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
-        {
-            Data = FakeEvent.Data with
-            {
-                AuthenticationContext = FakeEvent.Data.AuthenticationContext with
-                {
-                    User = FakeEvent.Data.AuthenticationContext.User with
-                    {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
+            Data = FakeEvent.Data with {
+                AuthenticationContext = FakeEvent.Data.AuthenticationContext with {
+                    User = FakeEvent.Data.AuthenticationContext.User with {
                         Mail = "abc",
                     },
                 },
@@ -107,14 +96,10 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
-        {
-            Data = FakeEvent.Data with
-            {
-                AuthenticationContext = FakeEvent.Data.AuthenticationContext with
-                {
-                    User = FakeEvent.Data.AuthenticationContext.User with
-                    {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
+            Data = FakeEvent.Data with {
+                AuthenticationContext = FakeEvent.Data.AuthenticationContext with {
+                    User = FakeEvent.Data.AuthenticationContext.User with {
                         GivenName = "",
                     },
                 },
@@ -133,14 +118,10 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
-        {
-            Data = FakeEvent.Data with
-            {
-                AuthenticationContext = FakeEvent.Data.AuthenticationContext with
-                {
-                    User = FakeEvent.Data.AuthenticationContext.User with
-                    {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
+            Data = FakeEvent.Data with {
+                AuthenticationContext = FakeEvent.Data.AuthenticationContext with {
+                    User = FakeEvent.Data.AuthenticationContext.User with {
                         Surname = "",
                     },
                 },
@@ -159,15 +140,13 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
 
         autoMocker.MockResponse(
-            new AutoLinkEntraUserToDsiRequest
-            {
+            new AutoLinkEntraUserToDsiRequest {
                 EntraUserId = new Guid("21892c65-88df-4268-b025-d06f51c52404"),
                 EmailAddress = "jo.bradford@example.com",
                 FirstName = "Jo",
                 LastName = "Bradford",
             },
-            new AutoLinkEntraUserToDsiResponse
-            {
+            new AutoLinkEntraUserToDsiResponse {
                 UserId = new Guid("d5ba1f44-1400-4c98-b834-5d5ba5b98995"),
             }
         );
@@ -192,29 +171,23 @@ public class TokenIssuanceStartHandlerTests
         var autoMocker = new AutoMocker();
 
         autoMocker.MockResponse(
-            new AutoLinkEntraUserToDsiRequest
-            {
+            new AutoLinkEntraUserToDsiRequest {
                 EntraUserId = new Guid("21892c65-88df-4268-b025-d06f51c52404"),
                 EmailAddress = "jo.bradford@example.com",
                 FirstName = "Jo",
                 LastName = "MAY - FINNEGAN",
             },
-            new AutoLinkEntraUserToDsiResponse
-            {
+            new AutoLinkEntraUserToDsiResponse {
                 UserId = new Guid("d5ba1f44-1400-4c98-b834-5d5ba5b98995"),
             }
         );
 
         var handler = autoMocker.CreateInstance<TokenIssuanceStartHandler>();
 
-        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with
-        {
-            Data = FakeEvent.Data with
-            {
-                AuthenticationContext = FakeEvent.Data.AuthenticationContext with
-                {
-                    User = FakeEvent.Data.AuthenticationContext.User with
-                    {
+        var fakeRequest = HttpServerMocking.CreateJsonRequest(FakeEvent with {
+            Data = FakeEvent.Data with {
+                AuthenticationContext = FakeEvent.Data.AuthenticationContext with {
+                    User = FakeEvent.Data.AuthenticationContext.User with {
                         Mail = "jo.bradford@example.com",
                         GivenName = " Jo ",
                         Surname = " MAY - FINNEGAN ",


### PR DESCRIPTION
PR Title
Fix token issuance failure for Entra compound surnames with spaced hyphen format

**Summary**
This PR fixes sign-in failures for users whose Entra surname contains the format space-hyphen-space (example: MAY - FINNEGAN).
The failure occurred during OnTokenIssuanceStart when LastName validation rejected this pattern and raised InvalidRequestException.

**Problem**
Users with compound surnames in this format could authenticate with Entra, but token issuance failed and surfaced a generic error page.

**Root Cause**
The shared name regex required each space-separated segment to begin with a letter or number.
For values like MAY - FINNEGAN, the segment after the space begins with hyphen, so validation failed.

**What Changed**
Updated the shared name pattern to allow a hyphen after a space as part of valid compound names.
Added defensive trimming in the token issuance handler before creating the auto-link request.
Added unit test coverage for compound surname formats using spaced hyphen.
Added handler test coverage to verify trimming behavior before dispatch.
Files Changed
StringPatterns.cs
TokenIssuanceStartHandler.cs
StringPatternsTests.cs
TokenIssuanceStartHandlerTests.cs

**Test Evidence**
Dfe.SignIn.Core.Contracts.UnitTests: 64 passed, 0 failed
Dfe.SignIn.Fn.AuthExtensions.UnitTests: 30 passed, 0 failed

**Acceptance Criteria Mapping**
MAY - FINNEGAN passes LastNamePattern: yes
Existing name pattern tests still pass: yes
New unit tests for hyphenated compound surname formats: yes
User with compound Entra surname can complete sign-in: addressed by regex fix and request input trimming in token issuance path
