### PR TITLE
Feature/dsi 8340 add missing appsettings

### DIFF
--- a/src/Dfe.SignIn.Web.Profile/appsettings.json
+++ b/src/Dfe.SignIn.Web.Profile/appsettings.json
@@ -20,6 +20,7 @@
     "ApplicationName": "Profile"
   },
   "Assets": {
+    "BaseAddress": "http://localhost:8081",
     "FrontendVersion": "12.0.9"
   },
   "Kestrel": {
@@ -82,5 +83,17 @@
       "TopicName": "<topic_name>",
       "SubscriptionName": "<topic_subscription_name>"
     }
+  },
+    "Platform": {
+    "HelpUrl": "http://localhost:5012",
+    "ProfileUrl": "http://localhost:41011",
+    "SurveyUrl": "https://survey.localhost",
+    "ServicesUrl": "https://services.localhost"
+  },
+   "SecurityHeaderPolicy": {
+    "AllowedOrigins": [
+      "*.signin.education.gov.uk",
+      "localhost:*"
+    ]
   }
 }

--- a/src/Dfe.SignIn.Web.Profile/appsettings.json
+++ b/src/Dfe.SignIn.Web.Profile/appsettings.json
@@ -75,5 +75,12 @@
   "GeneralRedisCache": {
     "ConnectionString": "localhost:6379,ssl=False",
     "DatabaseNumber": 8
+  },
+  "ServiceBus": {
+    "Namespace": "<service_bus_namespace>",
+    "ApplicationsTopic": {
+      "TopicName": "<topic_name>",
+      "SubscriptionName": "<topic_subscription_name>"
+    }
   }
 }

--- a/src/Dfe.SignIn.Web.Profile/appsettings.json
+++ b/src/Dfe.SignIn.Web.Profile/appsettings.json
@@ -58,5 +58,18 @@
     "ConnectionString": "localhost:6379,ssl=False",
     "DatabaseNumber": 3,
     "InstanceName": "token:"
+  },
+  "InternalApiClient": {
+    "BaseAddress": "<base_address>",
+    "ClientId": "<client_id>",
+    "ClientSecret": "<client_secret>",
+    "HostUrl": "<host_url>",
+    "Resource": "<resource>",
+    "Tenant": "<tenant_name>",
+    "Directories": {
+      "BaseAddress": "<base_address>"
+    },
+    "ProxyUrl": "<proxy_url>",
+    "UseProxy": true
   }
 }

--- a/src/Dfe.SignIn.Web.Profile/appsettings.json
+++ b/src/Dfe.SignIn.Web.Profile/appsettings.json
@@ -47,5 +47,11 @@
   "Session": {
     "DurationInMinutes": 20,
     "NotifyRemainingMinutes": 5
+  },
+  "Oidc": {
+    "ClientId": "<client_id>",
+    "ClientSecret": "<client_secret>",
+    "Authority": "<authority>",
+    "MetadataAddress": "<metadata_address>"
   }
 }

--- a/src/Dfe.SignIn.Web.Profile/appsettings.json
+++ b/src/Dfe.SignIn.Web.Profile/appsettings.json
@@ -53,5 +53,10 @@
     "ClientSecret": "<client_secret>",
     "Authority": "<authority>",
     "MetadataAddress": "<metadata_address>"
+  },
+  "TokenRedisCache": {
+    "ConnectionString": "localhost:6379,ssl=False",
+    "DatabaseNumber": 3,
+    "InstanceName": "token:"
   }
 }

--- a/src/Dfe.SignIn.Web.Profile/appsettings.json
+++ b/src/Dfe.SignIn.Web.Profile/appsettings.json
@@ -78,7 +78,7 @@
   },
   "ServiceBus": {
     "Namespace": "<service_bus_namespace>",
-    "ApplicationsTopic": {
+    "AuditTopic": {
       "TopicName": "<topic_name>",
       "SubscriptionName": "<topic_subscription_name>"
     }

--- a/src/Dfe.SignIn.Web.Profile/appsettings.json
+++ b/src/Dfe.SignIn.Web.Profile/appsettings.json
@@ -43,5 +43,9 @@
     "InitiateChangeEmailAddressRequest": {
       "Timeout": 15
     }
+  },
+  "Session": {
+    "DurationInMinutes": 20,
+    "NotifyRemainingMinutes": 5
   }
 }

--- a/src/Dfe.SignIn.Web.Profile/appsettings.json
+++ b/src/Dfe.SignIn.Web.Profile/appsettings.json
@@ -70,6 +70,10 @@
       "BaseAddress": "<base_address>"
     },
     "ProxyUrl": "<proxy_url>",
-    "UseProxy": true
+    "UseProxy": false
+  },
+  "GeneralRedisCache": {
+    "ConnectionString": "localhost:6379,ssl=False",
+    "DatabaseNumber": 8
   }
 }


### PR DESCRIPTION
The pipelines were continually failing owing to missing application settings.

Add settings so the pipeline runs successfully:

"Assets": "BaseAddress"
"Session" section
"Oidc" section
"TokenRedisCache" section
"InternalApiClient" section
"GeneralRedisCache" section
"ServiceBus" section
"Platform" section
"SecurityHeaderPolicy" section


