### PR TITLE
[DSI-8701] Fix: align blocked email matching with Node.js 

### DIFF
--- a/src/Dfe.SignIn.Core.UseCases/Users/CheckIsBlockedEmailAddressUseCase.cs
+++ b/src/Dfe.SignIn.Core.UseCases/Users/CheckIsBlockedEmailAddressUseCase.cs
@@ -68,16 +68,20 @@ public sealed partial class CheckIsBlockedEmailAddressUseCase(
 
         var options = optionsAccessor.CurrentValue;
 
-        string[] parts = context.Request.EmailAddress.ToLower().Split('@');
-        string name = TrimName().Replace(parts[0], "");
+        string[] parts = context.Request.EmailAddress.Split('@');
+        string localPart = parts[0];
         string domain = parts[1];
 
+        bool isBlockedDomain = options.BlockedDomains.Contains(domain, StringComparer.OrdinalIgnoreCase);
+        bool isBlockedName = options.BlockedNames.Any(blockedName =>
+            localPart.StartsWith(blockedName, StringComparison.OrdinalIgnoreCase)
+            && NameSuffix().IsMatch(localPart[blockedName.Length..]));
+
         return Task.FromResult(new CheckIsBlockedEmailAddressResponse {
-            IsBlocked = options.BlockedDomains.Contains(domain)
-                || options.BlockedNames.Contains(name),
+            IsBlocked = isBlockedDomain || isBlockedName,
         });
     }
 
-    [GeneratedRegex(@"[\d_.-]+$")]
-    private static partial Regex TrimName();
+    [GeneratedRegex(@"^[a-z0-9._-]*$", RegexOptions.IgnoreCase)]
+    private static partial Regex NameSuffix();
 }

--- a/tests/Dfe.SignIn.Core.UseCases.UnitTests/Users/CheckIsBlockedEmailAddressUseCaseTests.cs
+++ b/tests/Dfe.SignIn.Core.UseCases.UnitTests/Users/CheckIsBlockedEmailAddressUseCaseTests.cs
@@ -35,6 +35,7 @@ public sealed class CheckIsBlockedEmailAddressUseCaseTests
 
     [TestMethod]
     [DataRow("alex.hunter@example.com")]
+    [DataRow("xadmin@example.com")]
     public async Task ReturnsExpectedResponse_WhenEmailAddressIsPermitted(string emailAddress)
     {
         var autoMocker = new AutoMocker();
@@ -52,8 +53,12 @@ public sealed class CheckIsBlockedEmailAddressUseCaseTests
     [TestMethod]
     [DataRow("admin@example.com")]
     [DataRow("admin123@example.com")]
+    [DataRow("admin.test@example.com")]
+    [DataRow("admin_test@example.com")]
+    [DataRow("ADMIN@example.com")]
     [DataRow("staff@example.com")]
     [DataRow("alex.hunter@blocked.com")]
+    [DataRow("alex.hunter@BLOCKED.COM")]
     [DataRow("alex.hunter@blocked.other.com")]
     [DataRow("admin@blocked.com")]
     public async Task ReturnsExpectedResponse_WhenEmailAddressIsBlocked(string emailAddress)


### PR DESCRIPTION
— fix case-insensitive domain/name checks and allow alphanumeric suffixes on blocked names