### PR TITLE
[NSA-9733] Add UkrlpProviders organisation category

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,11 +52,11 @@
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
   <!-- HTTP / API -->
   <ItemGroup>

--- a/src/Dfe.SignIn.Core.Public/OrganisationCategory.cs
+++ b/src/Dfe.SignIn.Core.Public/OrganisationCategory.cs
@@ -91,4 +91,10 @@ public enum OrganisationCategory
     /// </summary>
     [Description("Youth Custody Service")]
     YouthCustodyService = 53,
+
+    /// <summary>
+    /// UKRLP providers.
+    /// </summary>
+    [Description("UKRLP Providers")]
+    UkrlpProviders = 54,
 }


### PR DESCRIPTION
src/Dfe.SignIn.Core.Public/OrganisationCategory.cs

- Added **UkrlpProviders = 54** to the OrganisationCategory enum
- Follows the existing 050–053 pattern (PIMS Training Providers, Billing Authority, Youth Custody Service)
- No further C# changes required — EnumHelpers.MapEnum<OrganisationCategory>() automatically maps string "054" to this value