### PR TITLE
[DSI-8739] Fix: Refine blocked email matching to allow real names and block reserved-name variants

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/src/Dfe.SignIn.Core.UseCases/Users/CheckIsBlockedEmailAddressUseCase.cs
+++ b/src/Dfe.SignIn.Core.UseCases/Users/CheckIsBlockedEmailAddressUseCase.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Dfe.SignIn.Base.Framework;
 using Dfe.SignIn.Core.Contracts.Users;
 using Microsoft.Extensions.Options;
@@ -73,15 +72,22 @@ public sealed partial class CheckIsBlockedEmailAddressUseCase(
         string domain = parts[1];
 
         bool isBlockedDomain = options.BlockedDomains.Contains(domain, StringComparer.OrdinalIgnoreCase);
-        bool isBlockedName = options.BlockedNames.Any(blockedName =>
-            localPart.Equals(blockedName, StringComparison.OrdinalIgnoreCase)
-            && NameSuffix().IsMatch(localPart[blockedName.Length..]));
+        bool isBlockedName = options.BlockedNames.Any(blockedName => {
+            if (!localPart.StartsWith(blockedName, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            if (localPart.Length == blockedName.Length) {
+                return true;
+            }
+
+            char nextChar = localPart[blockedName.Length];
+            return char.IsDigit(nextChar)
+                || nextChar is '.' or '-' or '_';
+        });
 
         return Task.FromResult(new CheckIsBlockedEmailAddressResponse {
             IsBlocked = isBlockedDomain || isBlockedName,
         });
     }
-
-    [GeneratedRegex(@"^[a-z0-9._-]*$", RegexOptions.IgnoreCase)]
-    private static partial Regex NameSuffix();
 }

--- a/src/Dfe.SignIn.Core.UseCases/Users/CheckIsBlockedEmailAddressUseCase.cs
+++ b/src/Dfe.SignIn.Core.UseCases/Users/CheckIsBlockedEmailAddressUseCase.cs
@@ -74,7 +74,7 @@ public sealed partial class CheckIsBlockedEmailAddressUseCase(
 
         bool isBlockedDomain = options.BlockedDomains.Contains(domain, StringComparer.OrdinalIgnoreCase);
         bool isBlockedName = options.BlockedNames.Any(blockedName =>
-            localPart.StartsWith(blockedName, StringComparison.OrdinalIgnoreCase)
+            localPart.Equals(blockedName, StringComparison.OrdinalIgnoreCase)
             && NameSuffix().IsMatch(localPart[blockedName.Length..]));
 
         return Task.FromResult(new CheckIsBlockedEmailAddressResponse {

--- a/tests/Dfe.SignIn.Core.UseCases.UnitTests/Users/CheckIsBlockedEmailAddressUseCaseTests.cs
+++ b/tests/Dfe.SignIn.Core.UseCases.UnitTests/Users/CheckIsBlockedEmailAddressUseCaseTests.cs
@@ -29,6 +29,7 @@ public sealed class CheckIsBlockedEmailAddressUseCaseTests
                 BlockedNames = [
                     "admin",
                     "staff",
+                    "pat",
                 ],
             });
     }
@@ -36,6 +37,9 @@ public sealed class CheckIsBlockedEmailAddressUseCaseTests
     [TestMethod]
     [DataRow("alex.hunter@example.com")]
     [DataRow("xadmin@example.com")]
+    [DataRow("staffmember@example.com")]
+    [DataRow("patrick@example.com")]
+    [DataRow("peter@example.com")]
     public async Task ReturnsExpectedResponse_WhenEmailAddressIsPermitted(string emailAddress)
     {
         var autoMocker = new AutoMocker();
@@ -57,6 +61,10 @@ public sealed class CheckIsBlockedEmailAddressUseCaseTests
     [DataRow("admin_test@example.com")]
     [DataRow("ADMIN@example.com")]
     [DataRow("staff@example.com")]
+    [DataRow("STAFF@example.com")]
+    [DataRow("pat@example.com")]
+    [DataRow("pat123@example.com")]
+    [DataRow("pat.test@example.com")]
     [DataRow("alex.hunter@blocked.com")]
     [DataRow("alex.hunter@BLOCKED.COM")]
     [DataRow("alex.hunter@blocked.other.com")]


### PR DESCRIPTION
Updated blocked email-name matching to support reserved-name variants while reducing false positives.

What was added:
Name blocking now checks for a blocked prefix in a case-insensitive way.
It blocks when the local-part is an exact blocked name.
It also blocks when the next character after the blocked prefix is:
a digit
a dot
a hyphen
an underscore
It allows real-name continuations where the next character is a letter, preventing overblocking of normal users.