### PR TITLE
fix: resolve SonarQube Docker security hotspots

### DIFF
--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build and process documentation ---
-FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:c804b88aaca8d6b76f65998427adec3101dcbbf2e52e705e2509eb81263aab0c AS build
+FROM mcr.microsoft.com/dotnet/sdk@sha256:c804b88aaca8d6b76f65998427adec3101dcbbf2e52e705e2509eb81263aab0c AS build
 
 WORKDIR /work
 
@@ -31,8 +31,10 @@ RUN FRONTEND_VERSION=$( \
 
 
 # --- Serve with a lightweight non-root version of nginx ---
-FROM nginxinc/nginx-unprivileged:1.29-alpine3.22@sha256:3245911073f8a6f8f5257aa08339096f90ef8d5db70f502f8ffeb2b9ecd5ca18
+FROM nginxinc/nginx-unprivileged@sha256:3245911073f8a6f8f5257aa08339096f90ef8d5db70f502f8ffeb2b9ecd5ca18
 
 COPY docker/docs/nginx.conf /etc/nginx/templates/default.conf.template
 
 COPY --from=build /_site /usr/share/nginx/html
+
+USER nginx

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official .NET SDK image as the base image for building the application
-FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:c804b88aaca8d6b76f65998427adec3101dcbbf2e52e705e2509eb81263aab0c AS build
+FROM mcr.microsoft.com/dotnet/sdk@sha256:c804b88aaca8d6b76f65998427adec3101dcbbf2e52e705e2509eb81263aab0c AS build
 
 WORKDIR /build
 
@@ -11,7 +11,7 @@ COPY *.targets ./
 RUN dotnet publish -c Release -o /app "src/$PROJECT_NAME/$PROJECT_NAME.csproj" /p:AutomatedRun=true
 
 # Use the official ASP.NET runtime image for the Azure Linux-based container
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-azurelinux3.0@sha256:dca725aa6ebe67b02b394b226cca9e7df1c2cf65ada0f70440bda4198d71a69f
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:dca725aa6ebe67b02b394b226cca9e7df1c2cf65ada0f70440bda4198d71a69f
 
 ARG PROJECT_NAME
 ENV PROJECT_NAME=$PROJECT_NAME

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,19 +1,21 @@
 # --- Build frontend assets ---
-FROM node:22-alpine@sha256:cb3143549582cc5f74f26f0992cdef4a422b22128cb517f94173a5f910fa4ee7 AS assets
+FROM node@sha256:cb3143549582cc5f74f26f0992cdef4a422b22128cb517f94173a5f910fa4ee7 AS assets
 
 COPY ./frontend /frontend
 
 WORKDIR /frontend
 
-RUN npm install --ignore-scripts && \
+RUN npm ci --ignore-scripts && \
     npm run build
 
 
 # --- Serve with a lightweight non-root version of nginx ---
-FROM nginxinc/nginx-unprivileged:1.29-alpine3.22@sha256:3245911073f8a6f8f5257aa08339096f90ef8d5db70f502f8ffeb2b9ecd5ca18
+FROM nginxinc/nginx-unprivileged@sha256:3245911073f8a6f8f5257aa08339096f90ef8d5db70f502f8ffeb2b9ecd5ca18
 
 COPY --from=assets /frontend/dist /usr/share/nginx/html/assets
 COPY --from=assets /frontend/node_modules/govuk-frontend/dist/govuk/assets /usr/share/nginx/html/assets/assets
 COPY --from=assets /frontend/assets /usr/share/nginx/html/assets/assets
 
 COPY docker/frontend/nginx.conf /etc/nginx/templates/default.conf.template
+
+USER nginx

--- a/docker/functions/Dockerfile
+++ b/docker/functions/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:c804b88aaca8d6b76f65998427adec3101dcbbf2e52e705e2509eb81263aab0c AS build
+FROM mcr.microsoft.com/dotnet/sdk@sha256:c804b88aaca8d6b76f65998427adec3101dcbbf2e52e705e2509eb81263aab0c AS build
 
 ARG PROJECT_NAME
 
@@ -13,7 +13,7 @@ RUN mkdir -p /home/site/wwwroot && \
 
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated10.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated10.0@sha256:af634f8ded5c98434d5f832de457fcc5f42738439ac55510a4070e2aa1a24802
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated@sha256:af634f8ded5c98434d5f832de457fcc5f42738439ac55510a4070e2aa1a24802
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 


### PR DESCRIPTION
- Use digest-only (no tag) for all FROM image references
- Replace npm install with npm ci to use lockfile
- Add explicit USER nginx to nginx-unprivileged final stages